### PR TITLE
Surpress error on update

### DIFF
--- a/src/c2m-plugin.ts
+++ b/src/c2m-plugin.ts
@@ -364,7 +364,11 @@ const plugin: Plugin = {
             chart.canvas.addEventListener("blur", () => {
                 chart.setActiveElements([]);
                 chart.tooltip?.setActiveElements([], {});
-                chart.update();
+                try {
+                    chart.update();
+                } catch(e){
+                    // console.warn(e);
+                }
             });
 
             // Show tooltip when the chart receives focus


### PR DESCRIPTION
In our use case chart.update() causes an error when tabbing out of a chart.

TypeError: node is null

This surpresses that error as it otherwise works okay. This is similar to https://github.com/julianna-langston/chartjs2music/blob/027c573a9d07385918aa893d439a1d14d5d2be32/src/c2m-plugin.ts#L194 I suspect this was added there for the same reason. The actual error should be further debugged.