### PR TITLE
Fix TypeError in scrubX()

### DIFF
--- a/src/c2m-plugin.ts
+++ b/src/c2m-plugin.ts
@@ -108,7 +108,7 @@ const scrubX = (data: any) => {
         // console.log("not grouped");
         // Not grouped
         blackboard.forEach((item, x) => {
-            if(typeof item === "object" && "x" in item){
+            if(typeof item === "object" && item !== null && "x" in item){
                 labels.push(item.x);
                 item.x = x;
             }


### PR DESCRIPTION
This fixes a possible TypeError:

```
TypeError: Cannot use 'in' operator to search for 'x' in null
```

This happens because `null` is also an `object`.