### PR TITLE
Allow users to override axes format in options

### DIFF
--- a/src/c2m-plugin.ts
+++ b/src/c2m-plugin.ts
@@ -75,13 +75,13 @@ const generateAxisInfo = (chartAxisInfo: any, chart: any) => {
     return axis;
 }
 
-const generateAxes = (chart: any, options: C2MPluginOptions) => {
+const generateAxes = (chart: any, options: any) => {
     const axes = {
         x: {
             ...generateAxisInfo(chart.options?.scales?.x, chart),
         },
         y: {
-            format: options.axes?.y?.format || ((value: number) => value.toLocaleString()),
+            format: options?.axes?.y?.format || ((value: number) => value.toLocaleString()),
             ...generateAxisInfo(chart.options?.scales?.y, chart),
         }
     };


### PR DESCRIPTION
This is to allow override of toLocaleString() behavior. To be honest, I think this might be worth breaking backwards compatibility (along with appropriate version bump if needed) and just return value here rather than assuming that we want to use the browser's default locale.