### PR TITLE
#364 - C2m options passthrough

### DIFF
--- a/src/c2m-plugin.ts
+++ b/src/c2m-plugin.ts
@@ -195,7 +195,7 @@ const displayPoint = (chart: Chart) => {
     const {point, index} = ref.getCurrent();
 
     // Use Chart2Music's internal visible group tracking
-     // @ts-ignore - accessing internal Chart2Music property
+    // @ts-ignore - accessing internal Chart2Music property
     const visibleGroupIndices = ref._visible_group_indices?.slice(1) || [];
 
     try{

--- a/src/plugin.d.ts
+++ b/src/plugin.d.ts
@@ -1,8 +1,8 @@
 import type { Plugin } from "chart.js";
 import type { C2MChartConfig } from "chart2music";
 
-export type C2MPluginOptions = Pick<C2MChartConfig, "audioEngine" | "axes" | "cc" | "lang"> & {
-    errorCallback: (err: string) => void
+export type C2MPluginOptions = Pick<C2MChartConfig, "audioEngine" | "axes" | "cc" | "lang" | "options"> & {
+    errorCallback?: (err: string) => void;
 }
 declare const plugin: Plugin;
 export default plugin;

--- a/tests/c2mOptions.test.ts
+++ b/tests/c2mOptions.test.ts
@@ -1,0 +1,68 @@
+import {Chart} from "chart.js";
+import plugin from "../src/c2m-plugin";
+import samples from "../samples/charts"
+
+const {simple_bar} = samples;
+
+Chart.register(plugin);
+
+test("Chart2Music options are passed through via plugin options", () => {
+    const mockElement = document.createElement("canvas");
+    const onSelectCallback = jest.fn();
+
+    new Chart(mockElement, {
+        ...simple_bar,
+        options: {
+            ...simple_bar.options,
+            plugins: {
+                ...simple_bar.options?.plugins,
+                chartjs2music: {
+                    // @ts-ignore
+                    options: {
+                        onSelectCallback,
+                        enableSound: false
+                    }
+                }
+            }
+        }
+    });
+
+    // Verify chart was created
+    expect(mockElement.getAttribute("tabIndex")).toBe("0");
+
+    // TODO: Test that onSelectCallback actually gets called
+    // This would require simulating Chart2Music interaction which is beyond
+    // the scope of this minimal test - just verifying the option is accepted
+});
+
+test("User's onFocusCallback works alongside plugin's internal callback", () => {
+    const mockParent = document.createElement("div");
+    const mockElement = document.createElement("canvas");
+    mockParent.appendChild(mockElement);
+    const userOnFocusCallback = jest.fn();
+
+    const chart = new Chart(mockElement, {
+        ...simple_bar,
+        options: {
+            ...simple_bar.options,
+            plugins: {
+                ...simple_bar.options?.plugins,
+                chartjs2music: {
+                    // @ts-ignore
+                    options: {
+                        onFocusCallback: userOnFocusCallback
+                    }
+                }
+            }
+        }
+    });
+
+    // Apply focus to trigger callbacks
+    mockElement.dispatchEvent(new Event("focus"));
+
+    // User's callback should have been called
+    expect(userOnFocusCallback).toHaveBeenCalled();
+
+    // Plugin's internal callback should have worked (CC element updated)
+    expect(mockParent.children[1].textContent).toContain(`Sonified chart`);
+});


### PR DESCRIPTION
In my use-case this supports translationCallback so that I can customize the points text, but this will support changing any of the c2mOptions, adding a great deal of flexibility - no changes in behavior for current users. Intended to address #364 