### PR TITLE
Support matrix plots

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@types/jest": "29.5.14",
     "canvas": "3.2.0",
     "chartjs-adapter-luxon": "1.3.1",
+    "chartjs-chart-matrix": "3.0.5",
     "chartjs-chart-wordcloud": "4.4.5",
     "chartjs-plugin-a11y-legend": "0.2.2",
     "cross-env": "7.0.3",

--- a/samples/charts/index.ts
+++ b/samples/charts/index.ts
@@ -22,6 +22,7 @@ import wordcloud from "./wordcloud";
 import wordcloud2 from "./wordcloud2";
 import scatter from "./scatter";
 import grouped_scatter from "./grouped_scatter";
+import matrix from "./matrix";
 import empty from "./empty";
 import memoryChart from "./memoryChart";
 
@@ -45,6 +46,7 @@ export default {
     box_plot_group_numbers,
     scatter,
     grouped_scatter,
+    matrix,
 
     wordcloud,
     wordcloud2,

--- a/samples/charts/index.ts
+++ b/samples/charts/index.ts
@@ -23,6 +23,11 @@ import wordcloud2 from "./wordcloud2";
 import scatter from "./scatter";
 import grouped_scatter from "./grouped_scatter";
 import matrix from "./matrix";
+import matrix_basic from "./matrix_basic";
+import matrix_calendar from "./matrix_calendar";
+import matrix_category from "./matrix_category";
+import matrix_c2m from "./matrix_c2m";
+import matrix_time from "./matrix_time";
 import empty from "./empty";
 import memoryChart from "./memoryChart";
 
@@ -47,6 +52,11 @@ export default {
     scatter,
     grouped_scatter,
     matrix,
+    matrix_basic,
+    matrix_category,
+    matrix_time,
+    matrix_calendar,
+    matrix_c2m,
 
     wordcloud,
     wordcloud2,

--- a/samples/charts/matrix.ts
+++ b/samples/charts/matrix.ts
@@ -2,7 +2,7 @@ import type { ChartConfiguration } from "chart.js";
 import type { MatrixDataPoint } from "chartjs-chart-matrix";
 
 const days = ["Mon", "Tue", "Wed", "Thu", "Fri"];
-const hours = ["9 AM", "12 PM", "3 PM", "6 PM"];
+const hours = ["9 AM", "12 PM", "3 PM"];
 
 const data: MatrixDataPoint[] = days.flatMap((day, x) => {
     return hours.map((hour, y) => ({

--- a/samples/charts/matrix.ts
+++ b/samples/charts/matrix.ts
@@ -1,0 +1,75 @@
+import type { ChartConfiguration } from "chart.js";
+import type { MatrixDataPoint } from "chartjs-chart-matrix";
+
+const days = ["Mon", "Tue", "Wed", "Thu", "Fri"];
+const hours = ["9 AM", "12 PM", "3 PM", "6 PM"];
+
+const data: MatrixDataPoint[] = days.flatMap((day, x) => {
+    return hours.map((hour, y) => ({
+        x: day,
+        y: hour,
+        v: [12, 18, 9, 14, 20, 27, 22, 16, 19, 30, 25, 21, 11, 17, 23, 28, 15, 26, 31, 24][x * hours.length + y]
+    }));
+});
+
+export default {
+    type: "matrix",
+    data: {
+        datasets: [{
+            label: "Library visitors",
+            data,
+            backgroundColor(context) {
+                const value = context.dataset.data[context.dataIndex]?.v ?? 0;
+                const alpha = Math.min(0.85, 0.2 + value / 40);
+                return `rgba(54, 162, 235, ${alpha})`;
+            },
+            borderColor: "rgb(255, 255, 255)",
+            borderWidth: 1,
+            width(context) {
+                const chartArea = context.chart.chartArea;
+                return chartArea ? chartArea.width / days.length - 1 : 40;
+            },
+            height(context) {
+                const chartArea = context.chart.chartArea;
+                return chartArea ? chartArea.height / hours.length - 1 : 40;
+            }
+        }]
+    },
+    options: {
+        plugins: {
+            title: {
+                display: true,
+                text: "Library Visitors by Day and Time"
+            },
+            legend: {
+                display: false
+            }
+        },
+        scales: {
+            x: {
+                type: "category",
+                labels: days,
+                offset: true,
+                title: {
+                    display: true,
+                    text: "Day"
+                },
+                grid: {
+                    display: false
+                }
+            },
+            y: {
+                type: "category",
+                labels: hours,
+                offset: true,
+                title: {
+                    display: true,
+                    text: "Time"
+                },
+                grid: {
+                    display: false
+                }
+            }
+        }
+    }
+} satisfies ChartConfiguration<"matrix", MatrixDataPoint[]>;

--- a/samples/charts/matrix_basic.ts
+++ b/samples/charts/matrix_basic.ts
@@ -1,0 +1,36 @@
+import type { ChartConfiguration } from "chart.js";
+import type { MatrixDataPoint } from "chartjs-chart-matrix";
+
+const data: MatrixDataPoint[] = [
+    {x: 1, y: 1, v: 11}, {x: 1, y: 2, v: 12}, {x: 1, y: 3, v: 13},
+    {x: 2, y: 1, v: 21}, {x: 2, y: 2, v: 22}, {x: 2, y: 3, v: 23},
+    {x: 3, y: 1, v: 31}, {x: 3, y: 2, v: 32}, {x: 3, y: 3, v: 33}
+];
+
+export default {
+    type: "matrix",
+    data: {
+        datasets: [{
+            label: "Documentation basic matrix",
+            data,
+            backgroundColor(context) {
+                const value = context.dataset.data[context.dataIndex]?.v ?? 0;
+                return `rgba(34, 139, 34, ${(value - 5) / 40})`;
+            },
+            borderColor: "rgb(0, 100, 0)",
+            borderWidth: 1,
+            width: ({chart}) => (chart.chartArea?.width ?? 120) / 3 - 1,
+            height: ({chart}) => (chart.chartArea?.height ?? 120) / 3 - 1
+        }]
+    },
+    options: {
+        plugins: {
+            title: {display: true, text: "Matrix Documentation: Basic Linear Scale"},
+            legend: {display: false}
+        },
+        scales: {
+            x: {title: {display: true, text: "Column"}, ticks: {stepSize: 1}, grid: {display: false}},
+            y: {title: {display: true, text: "Row"}, offset: true, ticks: {stepSize: 1}, grid: {display: false}}
+        }
+    }
+} satisfies ChartConfiguration<"matrix", MatrixDataPoint[]>;

--- a/samples/charts/matrix_c2m.ts
+++ b/samples/charts/matrix_c2m.ts
@@ -1,0 +1,39 @@
+import type { ChartConfiguration } from "chart.js";
+import type { MatrixDataPoint } from "chartjs-chart-matrix";
+
+const teams = ["Design", "Engineering", "Support", "Sales"];
+const weeks = ["Week 1", "Week 2", "Week 3", "Week 4"];
+const completion = [72, 90, 64, 81, 88, 76, 94, 69, 57, 83, 71, 92, 79, 61, 86, 74];
+const data: MatrixDataPoint[] = weeks.flatMap((x, week) => teams.map((y, team) => ({
+    x,
+    y,
+    v: completion[week * teams.length + team]
+})));
+
+export default {
+    type: "matrix",
+    data: {
+        datasets: [{
+            label: "Task completion",
+            data,
+            backgroundColor(context) {
+                const value = context.dataset.data[context.dataIndex]?.v ?? 0;
+                return `rgba(255, 140, 0, ${0.15 + value / 120})`;
+            },
+            borderColor: "rgb(170, 85, 0)",
+            borderWidth: 1,
+            width: ({chart}) => (chart.chartArea?.width ?? 240) / weeks.length - 1,
+            height: ({chart}) => (chart.chartArea?.height ?? 240) / teams.length - 1
+        }]
+    },
+    options: {
+        plugins: {
+            title: {display: true, text: "Chart2Music CodePen: Team Task Completion"},
+            legend: {display: false}
+        },
+        scales: {
+            x: {type: "category", labels: weeks, offset: true, title: {display: true, text: "Sprint"}, grid: {display: false}},
+            y: {type: "category", labels: teams, offset: true, title: {display: true, text: "Team"}, grid: {display: false}}
+        }
+    }
+} satisfies ChartConfiguration<"matrix", MatrixDataPoint[]>;

--- a/samples/charts/matrix_calendar.ts
+++ b/samples/charts/matrix_calendar.ts
@@ -1,0 +1,37 @@
+import type { ChartConfiguration } from "chart.js";
+import type { MatrixDataPoint } from "chartjs-chart-matrix";
+
+const dates = Array.from({length: 28}, (_, index) => new Date(Date.UTC(2026, 1, index + 1)).toISOString().slice(0, 10));
+const data: MatrixDataPoint[] = dates.map((y, index) => ({
+    x: (index % 7) + 1,
+    y,
+    v: 8 + (index * 11) % 42
+}));
+
+export default {
+    type: "matrix",
+    data: {
+        datasets: [{
+            label: "Documentation calendar matrix",
+            data,
+            backgroundColor(context) {
+                const value = context.dataset.data[context.dataIndex]?.v ?? 0;
+                return `rgba(186, 85, 211, ${(10 + value) / 60})`;
+            },
+            borderColor: "rgb(120, 45, 140)",
+            borderWidth: 1,
+            width: ({chart}) => (chart.chartArea?.width ?? 280) / 7 - 2,
+            height: ({chart}) => (chart.chartArea?.height ?? 280) / 4 - 2
+        }]
+    },
+    options: {
+        plugins: {
+            title: {display: true, text: "Matrix Documentation: Calendar"},
+            legend: {display: false}
+        },
+        scales: {
+            x: {offset: true, ticks: {stepSize: 1}, title: {display: true, text: "Day of Week"}, grid: {display: false}},
+            y: {type: "time", time: {unit: "week"}, offset: true, reverse: true, title: {display: true, text: "Week"}, grid: {display: false}}
+        }
+    }
+} satisfies ChartConfiguration<"matrix", MatrixDataPoint[]>;

--- a/samples/charts/matrix_category.ts
+++ b/samples/charts/matrix_category.ts
@@ -1,0 +1,38 @@
+import type { ChartConfiguration } from "chart.js";
+import type { MatrixDataPoint } from "chartjs-chart-matrix";
+
+const columns = ["A", "B", "C"];
+const rows = ["X", "Y", "Z"];
+const data: MatrixDataPoint[] = columns.flatMap((x, column) => rows.map((y, row) => ({
+    x,
+    y,
+    v: (column + 1) * 10 + row + 1
+})));
+
+export default {
+    type: "matrix",
+    data: {
+        datasets: [{
+            label: "Documentation category matrix",
+            data,
+            backgroundColor(context) {
+                const value = context.dataset.data[context.dataIndex]?.v ?? 0;
+                return `rgba(30, 144, 255, ${(value - 5) / 40})`;
+            },
+            borderColor: "rgb(25, 90, 160)",
+            borderWidth: 1,
+            width: ({chart}) => (chart.chartArea?.width ?? 120) / columns.length - 1,
+            height: ({chart}) => (chart.chartArea?.height ?? 120) / rows.length - 1
+        }]
+    },
+    options: {
+        plugins: {
+            title: {display: true, text: "Matrix Documentation: Category Scale"},
+            legend: {display: false}
+        },
+        scales: {
+            x: {type: "category", labels: columns, offset: true, title: {display: true, text: "Category"}, grid: {display: false}},
+            y: {type: "category", labels: rows, offset: true, title: {display: true, text: "Group"}, grid: {display: false}}
+        }
+    }
+} satisfies ChartConfiguration<"matrix", MatrixDataPoint[]>;

--- a/samples/charts/matrix_time.ts
+++ b/samples/charts/matrix_time.ts
@@ -1,0 +1,38 @@
+import type { ChartConfiguration } from "chart.js";
+import type { MatrixDataPoint } from "chartjs-chart-matrix";
+
+const days = Array.from({length: 28}, (_, index) => new Date(Date.UTC(2026, 0, index + 1)).toISOString().slice(0, 10));
+const data: MatrixDataPoint[] = days.map((x, index) => ({
+    x,
+    y: (index % 7) + 1,
+    v: 10 + (index * 7) % 40
+}));
+
+export default {
+    type: "matrix",
+    data: {
+        datasets: [{
+            label: "Documentation time matrix",
+            data,
+            backgroundColor(context) {
+                const value = context.dataset.data[context.dataIndex]?.v ?? 0;
+                return `rgba(46, 139, 87, ${(10 + value) / 60})`;
+            },
+            borderColor: "rgb(25, 100, 70)",
+            borderWidth: 1,
+            width: ({chart}) => (chart.chartArea?.width ?? 530) / 4 - 1,
+            height: ({chart}) => (chart.chartArea?.height ?? 140) / 7 - 1
+        }]
+    },
+    options: {
+        aspectRatio: 4,
+        plugins: {
+            title: {display: true, text: "Matrix Documentation: Time Scale"},
+            legend: {display: false}
+        },
+        scales: {
+            x: {type: "time", time: {unit: "week"}, offset: true, title: {display: true, text: "Date"}, grid: {display: false}},
+            y: {offset: true, ticks: {stepSize: 1}, title: {display: true, text: "Day of Week"}, grid: {display: false}}
+        }
+    }
+} satisfies ChartConfiguration<"matrix", MatrixDataPoint[]>;

--- a/samples/makeChart.ts
+++ b/samples/makeChart.ts
@@ -3,12 +3,13 @@ import plugin from "../src/c2m-plugin";
 import samples from "./charts";
 import {BoxPlotController, BoxAndWiskers} from "@sgratzl/chartjs-chart-boxplot";
 import { WordCloudController, WordElement } from 'chartjs-chart-wordcloud';
+import { MatrixController, MatrixElement } from "chartjs-chart-matrix";
 import legendPlugin from "chartjs-plugin-a11y-legend";
 import 'chartjs-adapter-luxon';
 
 const charts = Object.values(samples);
 
-Chart.register(BoxPlotController, BoxAndWiskers, WordCloudController, WordElement, legendPlugin);
+Chart.register(BoxPlotController, BoxAndWiskers, WordCloudController, WordElement, MatrixController, MatrixElement, legendPlugin);
 
 /*
 y2 axis

--- a/src/c2m-plugin.ts
+++ b/src/c2m-plugin.ts
@@ -325,6 +325,9 @@ const generateChart = (chart: Chart, options: C2MPluginOptions) => {
             axes.x.valueLabels = processedData.xLabels.slice(0);
         }
         if(processedData.yLabels?.length > 0){
+            // Category labels provide the Matrix Plot's Y-axis formatter.
+            // The general numeric formatter would otherwise announce row indexes.
+            delete axes.y.format;
             axes.y.valueLabels = processedData.yLabels.slice(0);
         }
     }

--- a/src/c2m-plugin.ts
+++ b/src/c2m-plugin.ts
@@ -6,6 +6,7 @@ import {processBoxData} from "./boxplots";
 type CustomDataPoint = {
     group: number;
     index: number;
+    datasetIndex?: number;
 };
 
 // Type for data manipulation
@@ -14,6 +15,8 @@ type DataSet = NonNullable<C2MChartConfig['data']>;
 type ChartStatesTypes = {
     c2m: c2m;
     lastDataSnapshot: string;
+    matrixKeydown?: (event: KeyboardEvent) => void;
+    matrixKeydownTarget?: HTMLCanvasElement;
 }
 
 const chartStates = new Map<Chart, ChartStatesTypes>();
@@ -125,14 +128,20 @@ const labelIndex = (labels: string[], value: string) => {
     return index;
 }
 
-const processMatrixDataPoints = (data: any[], xLabels: string[], yLabels: string[]) => {
-    return data.map((point: any) => {
+const processMatrixDataPoints = (data: any[], datasetIndex: number, xLabels: string[], yLabels: string[]) => {
+    return data.map((point: any, index: number) => {
         const x = typeof point.x === "string" ? labelIndex(xLabels, point.x) : point.x;
         const y = typeof point.y === "string" ? labelIndex(yLabels, point.y) : point.y;
         return {
             ...point,
             x,
-            y
+            y,
+            custom: {
+                ...point.custom,
+                group: datasetIndex,
+                datasetIndex,
+                index
+            }
         };
     });
 }
@@ -141,23 +150,27 @@ const processMatrixData = (data: any) => {
     const xLabels: string[] = [];
     const yLabels: string[] = [];
 
-    if(data.datasets.length === 1){
-        return {
-            data: processMatrixDataPoints(data.datasets[0].data, xLabels, yLabels),
-            xLabels,
-            yLabels
-        };
-    }
-
-    const groups: string[] = [];
-    const result = {} as Record<string, any>;
+    // Chart2Music represents matrix rows as groups and columns as points within
+    // each group. This preserves two-dimensional keyboard navigation.
+    const result = {} as Record<string, any[]>;
     data.datasets.forEach((obj: any, index: number) => {
-        const groupName = obj.label ?? `Group ${index+1}`;
-        groups.push(groupName);
-
-        result[groupName] = processMatrixDataPoints(obj.data, xLabels, yLabels);
+        const points = processMatrixDataPoints(obj.data, index, xLabels, yLabels);
+        points.forEach((point: any) => {
+            const rowLabel = typeof point.y === "number" && yLabels[point.y] !== undefined
+                ? yLabels[point.y]
+                : String(point.y);
+            const groupName = data.datasets.length === 1
+                ? rowLabel
+                : `${obj.label ?? `Group ${index + 1}`}: ${rowLabel}`;
+            if(!result[groupName]){
+                result[groupName] = [];
+            }
+            result[groupName].push(point);
+        });
     });
-    return {groups, data: result, xLabels, yLabels};
+
+    Object.values(result).forEach((row) => row.sort((a, b) => a.x - b.x));
+    return {groups: Object.keys(result), data: result, xLabels, yLabels};
 }
 
 const scrubX = (data: any) => {
@@ -251,7 +264,7 @@ const displayPoint = (chart: Chart) => {
         if("custom" in point){
             const customPoint = point as typeof point & { custom: CustomDataPoint };
             highlightElements.push({
-                datasetIndex: customPoint.custom.group,
+                datasetIndex: customPoint.custom.datasetIndex ?? customPoint.custom.group,
                 index: customPoint.custom.index
             });
         }else{
@@ -360,8 +373,9 @@ const generateChart = (chart: Chart, options: C2MPluginOptions) => {
                 return {
                     ...point,
                     custom: {
-                        group: 0,
-                        index
+                        ...point.custom,
+                        group: point.custom?.group ?? 0,
+                        index: point.custom?.index ?? index
                     }
                 }
             }) as DataSet;
@@ -397,8 +411,9 @@ const generateChart = (chart: Chart, options: C2MPluginOptions) => {
                     return {
                         ...point,
                         custom: {
-                            group: groupNumber,
-                            index
+                            ...point.custom,
+                            group: point.custom?.group ?? groupNumber,
+                            index: point.custom?.index ?? index
                         }
                     }
                 })
@@ -440,6 +455,26 @@ const generateChart = (chart: Chart, options: C2MPluginOptions) => {
         c2m,
         lastDataSnapshot: createDataSnapshot(chart)
     });
+
+    if(c2m_types === "matrix"){
+        const matrixKeydown = (event: KeyboardEvent) => {
+            if(event.key !== "ArrowUp" && event.key !== "ArrowDown"){
+                return;
+            }
+            event.preventDefault();
+            event.stopImmediatePropagation();
+            const actions = (c2m as any)._availableActions;
+            if(event.key === "ArrowUp"){
+                actions.next_category();
+            }else{
+                actions.previous_category();
+            }
+        };
+        chart.canvas.addEventListener("keydown", matrixKeydown, true);
+        const state = chartStates.get(chart) as ChartStatesTypes;
+        state.matrixKeydown = matrixKeydown;
+        state.matrixKeydownTarget = chart.canvas;
+    }
 
 }
 
@@ -527,11 +562,15 @@ const plugin: Plugin = {
     },
 
     afterDestroy: (chart) => {
-        const {c2m: ref} = chartStates.get(chart) as ChartStatesTypes;
-        if(!ref){
+        const state = chartStates.get(chart);
+        if(!state?.c2m){
             return;
         }
+        const {c2m: ref} = state;
 
+        if(state?.matrixKeydown && state.matrixKeydownTarget){
+            state.matrixKeydownTarget.removeEventListener("keydown", state.matrixKeydown, true);
+        }
         ref.cleanUp();
     },
 

--- a/src/c2m-plugin.ts
+++ b/src/c2m-plugin.ts
@@ -27,7 +27,8 @@ const chartjs_c2m_converter: any = {
     boxplot: "box",
     radar: "bar",
     wordCloud: "bar",
-    scatter: "scatter"
+    scatter: "scatter",
+    matrix: "matrix"
 };
 
 const processChartType = (chart: any) => {
@@ -115,6 +116,50 @@ const whichDataStructure = (data: any[]) => {
     return data;
 }
 
+const labelIndex = (labels: string[], value: string) => {
+    let index = labels.indexOf(value);
+    if(index === -1){
+        labels.push(value);
+        index = labels.length - 1;
+    }
+    return index;
+}
+
+const processMatrixDataPoints = (data: any[], xLabels: string[], yLabels: string[]) => {
+    return data.map((point: any) => {
+        const x = typeof point.x === "string" ? labelIndex(xLabels, point.x) : point.x;
+        const y = typeof point.y === "string" ? labelIndex(yLabels, point.y) : point.y;
+        return {
+            ...point,
+            x,
+            y
+        };
+    });
+}
+
+const processMatrixData = (data: any) => {
+    const xLabels: string[] = [];
+    const yLabels: string[] = [];
+
+    if(data.datasets.length === 1){
+        return {
+            data: processMatrixDataPoints(data.datasets[0].data, xLabels, yLabels),
+            xLabels,
+            yLabels
+        };
+    }
+
+    const groups: string[] = [];
+    const result = {} as Record<string, any>;
+    data.datasets.forEach((obj: any, index: number) => {
+        const groupName = obj.label ?? `Group ${index+1}`;
+        groups.push(groupName);
+
+        result[groupName] = processMatrixDataPoints(obj.data, xLabels, yLabels);
+    });
+    return {groups, data: result, xLabels, yLabels};
+}
+
 const scrubX = (data: any) => {
     const blackboard = JSON.parse(JSON.stringify(data));
 
@@ -139,6 +184,9 @@ const scrubX = (data: any) => {
 const processData = (data: any, c2m_types: string) => {
     if(c2m_types === "box"){
         return processBoxData(data);
+    }
+    if(c2m_types === "matrix"){
+        return processMatrixData(data);
     }
     let groups: string[] = [];
 
@@ -255,8 +303,18 @@ const generateChart = (chart: Chart, options: C2MPluginOptions) => {
     // Generate CC element
     const cc = determineCCElement(chart.canvas, options.cc);
 
-    const {data} = processData(chart.data, c2m_types);
+    const processedData = processData(chart.data, c2m_types);
+    const {data} = processedData;
     // lastDataObj = JSON.stringify(data);
+
+    if(c2m_types === "matrix"){
+        if(processedData.xLabels?.length > 0){
+            axes.x.valueLabels = processedData.xLabels.slice(0);
+        }
+        if(processedData.yLabels?.length > 0){
+            axes.y.valueLabels = processedData.yLabels.slice(0);
+        }
+    }
 
     let scrub = scrubX(data);
     if(scrub?.labels && scrub?.labels?.length > 0){   // Something was scrubbed

--- a/tests/errorHandling.test.ts
+++ b/tests/errorHandling.test.ts
@@ -26,5 +26,5 @@ test("Warn for invalid chart types", () => {
     
     expect(errorMockFn.mock.calls).toHaveLength(1);
     // @ts-ignore
-    expect(errorMockFn.mock.calls[0][0]).toBe(`Unable to connect chart2music to chart. The chart is of type \"bubble\", which is not one of the supported chart types for this plugin. This plugin supports: bar, line, pie, polarArea, doughnut, boxplot, radar, wordCloud, scatter`);
+    expect(errorMockFn.mock.calls[0][0]).toBe(`Unable to connect chart2music to chart. The chart is of type \"bubble\", which is not one of the supported chart types for this plugin. This plugin supports: bar, line, pie, polarArea, doughnut, boxplot, radar, wordCloud, scatter, matrix`);
 });

--- a/tests/matrix.test.ts
+++ b/tests/matrix.test.ts
@@ -1,5 +1,54 @@
+import {CategoryScale, Chart, LinearScale} from "chart.js";
+import {MatrixController, MatrixElement} from "chartjs-chart-matrix";
+import plugin from "../src/c2m-plugin";
+import matrixChart from "../samples/charts/matrix";
+
+Chart.register(CategoryScale, LinearScale, MatrixController, MatrixElement, plugin);
+
+(globalThis as any).AudioContext = class {};
+
+class MockAudioEngine {
+    masterGain = 0;
+
+    playDataPoint() {}
+}
+
 describe("Matrix charts", () => {
-    test.todo("creates a chart2music matrix chart from chartjs-chart-matrix data");
-    test.todo("uses category labels for string matrix x and y values");
-    test.todo("highlights the active matrix cell on focus and keyboard navigation");
+    test("navigates columns with right and rows with up", () => {
+        const createChart = () => {
+            const canvas = document.createElement("canvas");
+            const chart = new Chart(canvas, {
+                ...matrixChart,
+                options: {
+                    ...matrixChart.options,
+                    plugins: {
+                        ...matrixChart.options.plugins,
+                        chartjs2music: {
+                            audioEngine: new MockAudioEngine()
+                        }
+                    }
+                }
+            });
+            return {canvas, chart};
+        };
+
+        const horizontal = createChart();
+        horizontal.canvas.dispatchEvent(new Event("focus"));
+        horizontal.canvas.dispatchEvent(new KeyboardEvent("keydown", {key: "ArrowRight", bubbles: true}));
+        jest.advanceTimersByTime(250);
+        expect(horizontal.chart.getActiveElements()[0].datasetIndex).toBe(0);
+        expect(horizontal.chart.getActiveElements()[0].index).toBe(4);
+        horizontal.chart.destroy();
+
+        const vertical = createChart();
+        vertical.canvas.dispatchEvent(new Event("focus"));
+        vertical.canvas.dispatchEvent(new KeyboardEvent("keydown", {key: "ArrowUp", bubbles: true}));
+        jest.advanceTimersByTime(250);
+        expect(vertical.chart.getActiveElements()[0].datasetIndex).toBe(0);
+        expect(vertical.chart.getActiveElements()[0].index).toBe(1);
+        vertical.chart.destroy();
+    });
+
+    test.todo("uses numeric matrix coordinates without category labels");
+    test.todo("supports multiple matrix datasets");
 });

--- a/tests/matrix.test.ts
+++ b/tests/matrix.test.ts
@@ -16,7 +16,9 @@ class MockAudioEngine {
 describe("Matrix charts", () => {
     test("navigates columns with right and rows with up", () => {
         const createChart = () => {
+            const parent = document.createElement("div");
             const canvas = document.createElement("canvas");
+            parent.appendChild(canvas);
             const chart = new Chart(canvas, {
                 ...matrixChart,
                 options: {
@@ -29,15 +31,16 @@ describe("Matrix charts", () => {
                     }
                 }
             });
-            return {canvas, chart};
+            return {canvas, chart, parent};
         };
 
         const horizontal = createChart();
         horizontal.canvas.dispatchEvent(new Event("focus"));
+        expect(horizontal.parent.children[1].textContent).toContain('Y is "Time" from 9 AM to 3 PM.');
         horizontal.canvas.dispatchEvent(new KeyboardEvent("keydown", {key: "ArrowRight", bubbles: true}));
         jest.advanceTimersByTime(250);
         expect(horizontal.chart.getActiveElements()[0].datasetIndex).toBe(0);
-        expect(horizontal.chart.getActiveElements()[0].index).toBe(4);
+        expect(horizontal.chart.getActiveElements()[0].index).toBe(3);
         horizontal.chart.destroy();
 
         const vertical = createChart();

--- a/tests/matrix.test.ts
+++ b/tests/matrix.test.ts
@@ -1,0 +1,5 @@
+describe("Matrix charts", () => {
+    test.todo("creates a chart2music matrix chart from chartjs-chart-matrix data");
+    test.todo("uses category labels for string matrix x and y values");
+    test.todo("highlights the active matrix cell on focus and keyboard navigation");
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2249,6 +2249,11 @@ chartjs-adapter-luxon@1.3.1:
   resolved "https://registry.yarnpkg.com/chartjs-adapter-luxon/-/chartjs-adapter-luxon-1.3.1.tgz#8ad8be7cc1521bacd6cd2ff4b013669d4dd49364"
   integrity sha512-yxHov3X8y+reIibl1o+j18xzrcdddCLqsXhriV2+aQ4hCR66IYFchlRXUvrJVoxglJ380pgytU7YWtoqdIgqhg==
 
+chartjs-chart-matrix@3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/chartjs-chart-matrix/-/chartjs-chart-matrix-3.0.5.tgz#33df79ad2f5b9f782a9fbf3916e447dcc465ac52"
+  integrity sha512-hVqXBEtLoYJk+iA9NajA/ArG7HlPZl3XXNsRDY3c5sCuqSrM6uTythSJh1jVR7UNVApdY9PStb84xSEjEceKaw==
+
 chartjs-chart-wordcloud@4.4.5:
   version "4.4.5"
   resolved "https://registry.yarnpkg.com/chartjs-chart-wordcloud/-/chartjs-chart-wordcloud-4.4.5.tgz#29e7cd56a360ca474c03df467547aa27b460cc5b"


### PR DESCRIPTION
## Summary
- Adds chartjs-chart-matrix as a dev dependency for examples.
- Maps Chart.js matrix charts to chart2music matrix support.
- Converts string matrix x/y category values to numeric coordinates while preserving axis labels.
- Adds a matrix sample chart and registers the matrix controller/element in the sample app.
- Stubs matrix-specific test cases with todo coverage.

## Verification
- yarn depcheck
- yarn build
- yarn test