### PR TITLE
Support custom Chart.js axis identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ The plugin supports Chart.js bar, line, pie, doughnut, polar area, and scatter c
 - Box plots from [`@sgratzl/chartjs-chart-boxplot`](https://www.npmjs.com/package/@sgratzl/chartjs-chart-boxplot).
 - Matrix plots from [`chartjs-chart-matrix`](https://www.npmjs.com/package/chartjs-chart-matrix).
 - Word clouds from [`chartjs-chart-wordcloud`](https://www.npmjs.com/package/chartjs-chart-wordcloud).
-- Chart titles, axis titles, minimum and maximum values, linear and logarithmic axes, custom axis formatting, dataset visibility, and chart data updates.
+- Chart titles, axis titles, custom scale IDs, secondary Y axes, minimum and maximum values, linear and logarithmic axes, custom axis formatting, dataset visibility, and chart data updates.
 
-Visual-only Chart.js settings such as color, padding, and line thickness do not affect the sonification. Advanced Chart.js parsing configurations and nonstandard axis identifiers are not currently supported.
+Visual-only Chart.js settings such as color, padding, and line thickness do not affect the sonification. Advanced Chart.js parsing configurations are not currently supported.
 
 ## Future support
 

--- a/src/c2m-plugin.ts
+++ b/src/c2m-plugin.ts
@@ -15,6 +15,7 @@ type DataSet = NonNullable<C2MChartConfig['data']>;
 type ChartStatesTypes = {
     c2m: c2m;
     lastDataSnapshot: string;
+    axesResolved?: boolean;
     matrixKeydown?: (event: KeyboardEvent) => void;
     matrixKeydownTarget?: HTMLCanvasElement;
 }
@@ -90,23 +91,93 @@ const generateAxisInfo = (chartAxisInfo: any, chart: any) => {
     return axis;
 }
 
-const generateAxes = (chart: any, options: C2MPluginOptions) => {
-    const axes = {
+type ResolvedAxes = NonNullable<C2MChartConfig["axes"]> & {
+    x: NonNullable<NonNullable<C2MChartConfig["axes"]>["x"]>;
+    y: NonNullable<NonNullable<C2MChartConfig["axes"]>["y"]>;
+}
+
+type AxisResolution = {
+    axes: ResolvedAxes;
+    secondaryAxisDatasetIndexes: Set<number>;
+    error?: string;
+}
+
+const axisIds = (chart: any, axis: "x" | "y"): string[] => {
+    const resolvedIds = [...new Set<string>(chart.data.datasets.flatMap((_dataset: unknown, index: number): string[] => {
+        const scale = chart.getDatasetMeta(index)[`${axis}Scale`];
+        return scale?.id ? [String(scale.id)] : [];
+    }))];
+    if(resolvedIds.length > 0){
+        return resolvedIds;
+    }
+
+    const axisId = `${axis}AxisID`;
+    return [...new Set<string>(chart.data.datasets.flatMap((dataset: any): string[] => {
+        return dataset[axisId] ? [String(dataset[axisId])] : [];
+    }))];
+}
+
+const mergePluginAxes = (axes: ResolvedAxes, options: C2MPluginOptions): ResolvedAxes => {
+    const configuredAxes = options.axes;
+    return {
+        ...axes,
+        x: {...axes.x, ...configuredAxes?.x},
+        y: {...axes.y, ...configuredAxes?.y},
+        ...(axes.y2 ? {y2: {...axes.y2, ...configuredAxes?.y2}} : {})
+    } as ResolvedAxes;
+}
+
+const generateAxes = (chart: any, options: C2MPluginOptions): AxisResolution => {
+    const xAxisIds = axisIds(chart, "x");
+    const yAxisIds = axisIds(chart, "y");
+
+    if(xAxisIds.length > 1){
+        return {
+            axes: {} as ResolvedAxes,
+            secondaryAxisDatasetIndexes: new Set(),
+            error: `Unable to connect chart2music to chart. Multiple x-axis IDs are not supported: ${xAxisIds.join(", ")}.`
+        };
+    }
+
+    if(yAxisIds.length > 2){
+        return {
+            axes: {} as ResolvedAxes,
+            secondaryAxisDatasetIndexes: new Set(),
+            error: `Unable to connect chart2music to chart. More than two y-axis IDs are not supported: ${yAxisIds.join(", ")}.`
+        };
+    }
+
+    const xScale = xAxisIds[0] ? chart.scales[xAxisIds[0]] : chart.scales?.x;
+    const yScale = yAxisIds[0] ? chart.scales[yAxisIds[0]] : chart.scales?.y;
+    const y2Scale = yAxisIds[1] ? chart.scales[yAxisIds[1]] : undefined;
+    const axes: ResolvedAxes = {
         x: {
-            ...generateAxisInfo(chart.options?.scales?.x, chart),
+            ...generateAxisInfo(xScale?.options ?? chart.options?.scales?.x, chart),
         },
         y: {
             format: options?.axes?.y?.format || ((value: number) => value.toLocaleString()),
-            ...generateAxisInfo(chart.options?.scales?.y, chart),
+            ...generateAxisInfo(yScale?.options ?? chart.options?.scales?.y, chart),
         }
     };
 
-    const xAxisValueLabels = chart.data.labels.slice(0);
+    if(y2Scale){
+        axes.y2 = {
+            format: options?.axes?.y2?.format || ((value: number) => value.toLocaleString()),
+            ...generateAxisInfo(y2Scale.options, chart),
+        };
+    }
+
+    const xAxisValueLabels = xScale?.getLabels?.() ?? chart.data.labels?.slice(0) ?? [];
     if(xAxisValueLabels.length > 0){
         axes.x.valueLabels = xAxisValueLabels;
     }
 
-    return axes;
+    return {
+        axes: mergePluginAxes(axes, options),
+        secondaryAxisDatasetIndexes: y2Scale ? new Set(chart.data.datasets.flatMap((_dataset: unknown, index: number) => {
+            return chart.getDatasetMeta(index).yScale?.id === y2Scale.id ? [index] : [];
+        })) : new Set()
+    };
 }
 
 const whichDataStructure = (data: any[]) => {
@@ -173,6 +244,22 @@ const processMatrixData = (data: any) => {
     return {groups: Object.keys(result), data: result, xLabels, yLabels};
 }
 
+const useSecondaryAxis = (data: any[]) => {
+    return data.map((point, index) => {
+        if(typeof point === "number"){
+            return {x: index, y2: point};
+        }
+        if(typeof point !== "object" || point === null || Array.isArray(point)){
+            return point;
+        }
+        if(point.y === undefined){
+            return point;
+        }
+
+        const {y, ...values} = point;
+        return {x: values.x ?? index, ...values, y2: y};
+    });
+}
 const scrubX = (data: any) => {
     const blackboard = JSON.parse(JSON.stringify(data));
 
@@ -194,7 +281,7 @@ const scrubX = (data: any) => {
     }
 }
 
-const processData = (data: any, c2m_types: string) => {
+const processData = (data: any, c2m_types: string, secondaryAxisDatasets = new Set<number>()) => {
     if(c2m_types === "box"){
         return processBoxData(data);
     }
@@ -203,9 +290,13 @@ const processData = (data: any, c2m_types: string) => {
     }
     let groups: string[] = [];
 
+    const processValues = (values: any[], datasetIndex: number) => {
+        const axisData = secondaryAxisDatasets.has(datasetIndex) ? useSecondaryAxis(values) : values;
+        return whichDataStructure(axisData);
+    };
     if(data.datasets.length === 1){
         return {
-            data: whichDataStructure(data.datasets[0].data)
+            data: processValues(data.datasets[0].data, 0)
         }
     }
 
@@ -215,7 +306,7 @@ const processData = (data: any, c2m_types: string) => {
         const groupName = obj.label ?? `Group ${index+1}`;
         groups.push(groupName);
 
-        result[groupName] = whichDataStructure(obj.data);
+        result[groupName] = processValues(obj.data, index);
     });
 
     return {groups, data: result};
@@ -297,7 +388,12 @@ const generateChart = (chart: Chart, options: C2MPluginOptions) => {
         return;
     }
 
-    let axes = generateAxes(chart, options);
+    const axisResolution = generateAxes(chart, options);
+    if(axisResolution.error){
+        options.errorCallback?.(axisResolution.error);
+        return;
+    }
+    let axes = axisResolution.axes;
 
     if((chart.config as ChartConfiguration).type === "wordCloud" as keyof ChartTypeRegistry){
         delete axes.x.minimum;
@@ -316,7 +412,7 @@ const generateChart = (chart: Chart, options: C2MPluginOptions) => {
     // Generate CC element
     const cc = determineCCElement(chart.canvas, options.cc);
 
-    const processedData = processData(chart.data, c2m_types);
+    const processedData: any = processData(chart.data, c2m_types, axisResolution.secondaryAxisDatasetIndexes);
     const {data} = processedData;
     // lastDataObj = JSON.stringify(data);
 
@@ -343,18 +439,6 @@ const generateChart = (chart: Chart, options: C2MPluginOptions) => {
         delete scrub?.data;
         delete axes.x.valueLabels;
     }
-
-    axes = {
-        ...axes,
-        x: {
-            ...axes.x,
-            ...(options.axes?.x)
-        },
-        y: {
-            ...axes.y,
-            ...(options.axes?.y)
-        },
-    };
 
     // Start with plugin's internal onFocusCallback
     const pluginOnFocusCallback = () => {
@@ -469,7 +553,8 @@ const generateChart = (chart: Chart, options: C2MPluginOptions) => {
 
     chartStates.set(chart, {
         c2m,
-        lastDataSnapshot: createDataSnapshot(chart)
+        lastDataSnapshot: createDataSnapshot(chart),
+        axesResolved: false
     });
 
     if(c2m_types === "matrix"){
@@ -500,23 +585,23 @@ const plugin: Plugin = {
     afterInit: (chart: Chart, _args, options: C2MPluginOptions) => {
         if(!chartStates.has(chart)){
             generateChart(chart, options);
-
-            // Remove tooltip when the chart blurs
-            chart.canvas.addEventListener("blur", () => {
-                chart.setActiveElements([]);
-                chart.tooltip?.setActiveElements([], {} as Point);
-                try {
-                    chart.update();
-                } catch(e){
-                    // console.warn(e);
-                }
-            });
-
-            // Show tooltip when the chart receives focus
-            chart.canvas.addEventListener("focus", () => {
-                displayPoint(chart);
-            });
         }
+
+        // Remove tooltip when the chart blurs
+        chart.canvas.addEventListener("blur", () => {
+            chart.setActiveElements([]);
+            chart.tooltip?.setActiveElements([], {} as Point);
+            try {
+                chart.update();
+            } catch(e){
+                // console.warn(e);
+            }
+        });
+
+        // Show tooltip when the chart receives focus
+        chart.canvas.addEventListener("focus", () => {
+            displayPoint(chart);
+        });
     },
 
     afterDatasetUpdate: (chart: Chart, args, options: C2MPluginOptions) => {
@@ -528,7 +613,7 @@ const plugin: Plugin = {
             generateChart(chart, options);
         }
 
-        const {c2m: ref} = chartStates.get(chart) as ChartStatesTypes;
+        const {c2m: ref} = chartStates.get(chart) ?? {};
         if(!ref){
             return;
         }
@@ -552,13 +637,16 @@ const plugin: Plugin = {
         }
     },
 
-    afterDatasetsUpdate: (chart: Chart, _args, options: C2MPluginOptions) => {
+    afterUpdate: (chart: Chart, _args, options: C2MPluginOptions) => {
         const state = chartStates.get(chart);
-        if(!state?.c2m) return;
+        if(!state?.c2m){
+            generateChart(chart, options);
+            return;
+        }
 
         // Check if data has changed
         const currentSnapshot = createDataSnapshot(chart);
-        if(currentSnapshot === state.lastDataSnapshot) {
+        if(state.axesResolved && currentSnapshot === state.lastDataSnapshot) {
             return; // No data change, skip update
         }
 
@@ -567,14 +655,19 @@ const plugin: Plugin = {
         if(!valid) return;
 
         // Process data and generate axes
-        const {data} = processData(chart.data, c2m_types);
-        const axes = generateAxes(chart, options);
+        const axisResolution = generateAxes(chart, options);
+        if(axisResolution.error){
+            options.errorCallback?.(axisResolution.error);
+            return;
+        }
+        const {data} = processData(chart.data, c2m_types, axisResolution.secondaryAxisDatasetIndexes);
 
         // Update Chart2Music with new data
-        state.c2m.setData(data, axes);
+        state.c2m.setData(data, axisResolution.axes);
 
         // Update snapshot
         state.lastDataSnapshot = currentSnapshot;
+        state.axesResolved = true;
     },
 
     afterDestroy: (chart) => {

--- a/src/c2m-plugin.ts
+++ b/src/c2m-plugin.ts
@@ -99,6 +99,7 @@ type ResolvedAxes = NonNullable<C2MChartConfig["axes"]> & {
 type AxisResolution = {
     axes: ResolvedAxes;
     secondaryAxisDatasetIndexes: Set<number>;
+    requiresRefresh: boolean;
     error?: string;
 }
 
@@ -135,6 +136,7 @@ const generateAxes = (chart: any, options: C2MPluginOptions): AxisResolution => 
         return {
             axes: {} as ResolvedAxes,
             secondaryAxisDatasetIndexes: new Set(),
+            requiresRefresh: false,
             error: `Unable to connect chart2music to chart. Multiple x-axis IDs are not supported: ${xAxisIds.join(", ")}.`
         };
     }
@@ -143,6 +145,7 @@ const generateAxes = (chart: any, options: C2MPluginOptions): AxisResolution => 
         return {
             axes: {} as ResolvedAxes,
             secondaryAxisDatasetIndexes: new Set(),
+            requiresRefresh: false,
             error: `Unable to connect chart2music to chart. More than two y-axis IDs are not supported: ${yAxisIds.join(", ")}.`
         };
     }
@@ -176,7 +179,8 @@ const generateAxes = (chart: any, options: C2MPluginOptions): AxisResolution => 
         axes: mergePluginAxes(axes, options),
         secondaryAxisDatasetIndexes: y2Scale ? new Set(chart.data.datasets.flatMap((_dataset: unknown, index: number) => {
             return chart.getDatasetMeta(index).yScale?.id === y2Scale.id ? [index] : [];
-        })) : new Set()
+        })) : new Set(),
+        requiresRefresh: xAxisIds.some((id) => id !== "x") || yAxisIds.some((id) => id !== "y")
     };
 }
 
@@ -658,6 +662,10 @@ const plugin: Plugin = {
         const axisResolution = generateAxes(chart, options);
         if(axisResolution.error){
             options.errorCallback?.(axisResolution.error);
+            return;
+        }
+        if(!axisResolution.requiresRefresh && currentSnapshot === state.lastDataSnapshot){
+            state.axesResolved = true;
             return;
         }
         const {data} = processData(chart.data, c2m_types, axisResolution.secondaryAxisDatasetIndexes);

--- a/stories/charts/index.ts
+++ b/stories/charts/index.ts
@@ -30,6 +30,7 @@ import matrix_c2m from "./matrix_c2m";
 import matrix_time from "./matrix_time";
 import empty from "./empty";
 import memoryChart from "./memoryChart";
+import multi_axis from "./multi_axis";
 
 export default {
     simple_bar,
@@ -45,6 +46,7 @@ export default {
     string_x_minimum,
     string_x_values,
     memoryChart,
+    multi_axis,
     box_plot,
     box_plot_numbers,
     box_plot_group,

--- a/stories/charts/multi_axis.ts
+++ b/stories/charts/multi_axis.ts
@@ -1,0 +1,52 @@
+import type {ChartTypeRegistry} from "chart.js";
+
+export default {
+    type: "line" as keyof ChartTypeRegistry,
+    data: {
+        labels: ["January", "February", "March"],
+        datasets: [
+            {
+                label: "Revenue",
+                data: [120, 180, 150],
+                xAxisID: "period",
+                yAxisID: "revenue",
+                borderColor: "#2086d7"
+            },
+            {
+                label: "Profit margin",
+                data: [18, 24, 21],
+                xAxisID: "period",
+                yAxisID: "margin",
+                borderColor: "#1d8f5f"
+            }
+        ]
+    },
+    options: {
+        plugins: {
+            title: {
+                display: true,
+                text: "Revenue and Profit Margin"
+            }
+        },
+        scales: {
+            period: {
+                axis: "x",
+                type: "category",
+                title: {display: true, text: "Month"}
+            },
+            revenue: {
+                axis: "y",
+                type: "linear",
+                position: "left",
+                title: {display: true, text: "Revenue"}
+            },
+            margin: {
+                axis: "y",
+                type: "linear",
+                position: "right",
+                title: {display: true, text: "Profit margin"},
+                grid: {drawOnChartArea: false}
+            }
+        }
+    }
+};

--- a/stories/line.stories.ts
+++ b/stories/line.stories.ts
@@ -1,6 +1,7 @@
 import type {Meta, StoryObj} from "@storybook/html-vite";
 import groupedLine from "./charts/grouped_line";
 import memoryChart from "./charts/memoryChart";
+import multiAxis from "./charts/multi_axis";
 import {renderSample, type SampleStoryArgs} from "./sample-chart";
 
 const meta = {
@@ -13,3 +14,4 @@ type Story = StoryObj<typeof meta>;
 
 export const Grouped: Story = {args: {sample: groupedLine}};
 export const MemoryUsage: Story = {args: {sample: memoryChart}};
+export const MultiAxis: Story = {args: {sample: multiAxis}};

--- a/tests/axisIdentifiers.test.ts
+++ b/tests/axisIdentifiers.test.ts
@@ -1,0 +1,66 @@
+import {CategoryScale, Chart, LineController, LineElement, LinearScale, PointElement} from "chart.js";
+import plugin from "../src/c2m-plugin";
+import multiAxis from "../stories/charts/multi_axis";
+
+Chart.register(CategoryScale, LineController, LineElement, LinearScale, PointElement, plugin);
+
+test("uses custom scale IDs and exposes a secondary y axis", () => {
+    const parent = document.createElement("div");
+    const canvas = document.createElement("canvas");
+    const onFocusCallback = jest.fn();
+    parent.appendChild(canvas);
+
+    const chart = new Chart(canvas, {
+        ...multiAxis,
+        options: {
+            ...multiAxis.options,
+            plugins: {
+                ...multiAxis.options.plugins,
+                chartjs2music: {options: {onFocusCallback}}
+            }
+        }
+    } as any);
+
+    chart.update();
+
+    canvas.dispatchEvent(new Event("focus"));
+
+    expect(parent.children[1].textContent).toContain('X is "Month" from January to March.');
+    expect(parent.children[1].textContent).toContain('Y is "Revenue" from 120 to 180.');
+    expect(onFocusCallback).toHaveBeenCalledWith(expect.objectContaining({
+        point: expect.objectContaining({x: 0, y: 120})
+    }));
+
+    canvas.dispatchEvent(new KeyboardEvent("keydown", {key: "PageDown"}));
+    expect(parent.children[1].textContent).toContain('Alternate Y is "Profit margin" from 18 to 24.');
+    chart.destroy();
+});
+
+test("reports unsupported multiple x-axis assignments", () => {
+    const canvas = document.createElement("canvas");
+    const errorCallback = jest.fn();
+
+    const chart = new Chart(canvas, {
+        type: "line",
+        data: {
+            labels: ["January", "February"],
+            datasets: [
+                {label: "Revenue", data: [120, 180], xAxisID: "period", yAxisID: "revenue"},
+                {label: "Forecast", data: [130, 190], xAxisID: "forecastPeriod", yAxisID: "revenue"}
+            ]
+        },
+        options: {
+            plugins: {chartjs2music: {errorCallback}},
+            scales: {
+                period: {axis: "x", type: "category"},
+                forecastPeriod: {axis: "x", type: "category"},
+                revenue: {axis: "y", type: "linear"}
+            }
+        }
+    } as any);
+
+    chart.update();
+
+    expect(errorCallback).toHaveBeenCalledWith(expect.stringContaining("Multiple x-axis IDs are not supported"));
+    chart.destroy();
+});


### PR DESCRIPTION
## Summary
- resolve Chart.js dataset axes from their assigned `xAxisID` and `yAxisID` scale metadata
- convert datasets assigned to a second Y scale into Chart2Music alternate-axis (`y2`) data
- report unsupported configurations with multiple X scale IDs or more than two Y scale IDs
- add a `MultiAxis` Storybook example, regression tests, and README support coverage

Closes #402

## Validation
- `tsc --noEmit`
- focused Jest suite: axis identifiers, existing axis behavior, and data updates
- Rollup build
- Storybook build

The full Jest command remains blocked on main by the existing Babel 8 coverage instrumentation error (`generate is not a function`) and the untransformed ESM `chartjs-adapter-luxon` import in `tests/matrix.test.ts`.

## Reference
Implementation follows Chart.js's official multi-axis sample and documented `xAxisID` / `yAxisID` dataset-scale mapping, including explicit `axis` declarations for custom scale IDs.
- https://www.chartjs.org/docs/latest/samples/line/multi-axis.html
- https://www.chartjs.org/docs/latest/charts/line.html
- https://www.chartjs.org/docs/latest/axes/
