### PR TITLE
Support Chart.js subtitles

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The plugin supports Chart.js bar, line, pie, doughnut, polar area, and scatter c
 - Box plots from [`@sgratzl/chartjs-chart-boxplot`](https://www.npmjs.com/package/@sgratzl/chartjs-chart-boxplot).
 - Matrix plots from [`chartjs-chart-matrix`](https://www.npmjs.com/package/chartjs-chart-matrix).
 - Word clouds from [`chartjs-chart-wordcloud`](https://www.npmjs.com/package/chartjs-chart-wordcloud).
-- Chart titles, axis titles, minimum and maximum values, linear and logarithmic axes, custom axis formatting, dataset visibility, and chart data updates.
+- Chart titles and subtitles, axis titles, minimum and maximum values, linear and logarithmic axes, custom axis formatting, dataset visibility, and chart data updates.
 
 Visual-only Chart.js settings such as color, padding, and line thickness do not affect the sonification. Advanced Chart.js parsing configurations and nonstandard axis identifiers are not currently supported.
 
@@ -102,7 +102,6 @@ Visual-only Chart.js settings such as color, padding, and line thickness do not 
 
 Planned support includes:
 
-- Chart subtitles.
 - Radar plots.
 - Error bars via [`chartjs-chart-error-bars`](https://www.npmjs.com/package/chartjs-chart-error-bars).
 - Parallel coordinate plots via [`chartjs-chart-pcp`](https://www.npmjs.com/package/chartjs-chart-pcp).

--- a/src/c2m-plugin.ts
+++ b/src/c2m-plugin.ts
@@ -15,6 +15,8 @@ type DataSet = NonNullable<C2MChartConfig['data']>;
 type ChartStatesTypes = {
     c2m: c2m;
     lastDataSnapshot: string;
+    cc: HTMLElement;
+    title: string;
     matrixKeydown?: (event: KeyboardEvent) => void;
     matrixKeydownTarget?: HTMLCanvasElement;
 }
@@ -221,14 +223,18 @@ const processData = (data: any, c2m_types: string) => {
     return {groups, data: result};
 }
 
-const determineChartTitle = (options: ChartOptions) => {
-    if(options.plugins?.title?.text){
-        if(Array.isArray(options.plugins.title.text)){
-            return options.plugins.title.text.join(", ");
-        }
-        return options.plugins.title.text;
+const titleText = (text: unknown) => {
+    if(Array.isArray(text)){
+        return text.filter((line): line is string => typeof line === "string").join(", ");
     }
-    return "";
+    return typeof text === "string" ? text : "";
+}
+
+const determineChartTitle = (options: ChartOptions) => {
+    return [
+        titleText(options.plugins?.title?.text),
+        titleText(options.plugins?.subtitle?.text)
+    ].filter(Boolean).join(", ");
 }
 
 const determineCCElement = (canvas: HTMLCanvasElement, provided?: HTMLElement | null) => {
@@ -244,7 +250,8 @@ const determineCCElement = (canvas: HTMLCanvasElement, provided?: HTMLElement | 
 const createDataSnapshot = (chart: Chart) => {
     return JSON.stringify({
         datasets: chart.data.datasets.map(ds => ds.data),
-        labels: chart.data.labels
+        labels: chart.data.labels,
+        title: determineChartTitle(chart.options)
     });
 }
 
@@ -469,7 +476,9 @@ const generateChart = (chart: Chart, options: C2MPluginOptions) => {
 
     chartStates.set(chart, {
         c2m,
-        lastDataSnapshot: createDataSnapshot(chart)
+        lastDataSnapshot: createDataSnapshot(chart),
+        cc,
+        title: determineChartTitle(chart.options)
     });
 
     if(c2m_types === "matrix"){
@@ -560,6 +569,14 @@ const plugin: Plugin = {
         const currentSnapshot = createDataSnapshot(chart);
         if(currentSnapshot === state.lastDataSnapshot) {
             return; // No data change, skip update
+        }
+
+        const title = determineChartTitle(chart.options);
+        if(title !== state.title){
+            state.c2m.cleanUp();
+            chartStates.delete(chart);
+            generateChart(chart, {...options, cc: state.cc});
+            return;
         }
 
         // Get chart type

--- a/stories/charts/index.ts
+++ b/stories/charts/index.ts
@@ -30,6 +30,7 @@ import matrix_c2m from "./matrix_c2m";
 import matrix_time from "./matrix_time";
 import empty from "./empty";
 import memoryChart from "./memoryChart";
+import title_subtitle from "./title_subtitle";
 
 export default {
     simple_bar,
@@ -45,6 +46,7 @@ export default {
     string_x_minimum,
     string_x_values,
     memoryChart,
+    title_subtitle,
     box_plot,
     box_plot_numbers,
     box_plot_group,

--- a/stories/charts/title_subtitle.ts
+++ b/stories/charts/title_subtitle.ts
@@ -1,0 +1,23 @@
+import type {ChartTypeRegistry} from "chart.js";
+
+export default {
+    type: "line" as keyof ChartTypeRegistry,
+    data: {
+        labels: ["January", "February", "March"],
+        datasets: [{
+            label: "Sales",
+            data: [12, 19, 15],
+            borderColor: "#2086d7"
+        }]
+    },
+    options: {
+        plugins: {
+            title: {display: true, text: "Monthly Sales"},
+            subtitle: {display: true, text: "North America"}
+        },
+        scales: {
+            x: {title: {display: true, text: "Month"}},
+            y: {title: {display: true, text: "Sales"}}
+        }
+    }
+};

--- a/stories/line.stories.ts
+++ b/stories/line.stories.ts
@@ -1,6 +1,7 @@
 import type {Meta, StoryObj} from "@storybook/html-vite";
 import groupedLine from "./charts/grouped_line";
 import memoryChart from "./charts/memoryChart";
+import titleSubtitle from "./charts/title_subtitle";
 import {renderSample, type SampleStoryArgs} from "./sample-chart";
 
 const meta = {
@@ -13,3 +14,4 @@ type Story = StoryObj<typeof meta>;
 
 export const Grouped: Story = {args: {sample: groupedLine}};
 export const MemoryUsage: Story = {args: {sample: memoryChart}};
+export const TitleAndSubtitle: Story = {args: {sample: titleSubtitle}};

--- a/tests/chartTitles.test.ts
+++ b/tests/chartTitles.test.ts
@@ -1,0 +1,65 @@
+import {BarController, BarElement, CategoryScale, Chart, LinearScale} from "chart.js";
+import plugin from "../src/c2m-plugin";
+
+Chart.register(BarController, BarElement, CategoryScale, LinearScale, plugin);
+
+const createChart = (title?: string | string[], subtitle?: string | string[]) => {
+    const canvas = document.createElement("canvas");
+    const cc = document.createElement("div");
+    const chart = new Chart(canvas, {
+        type: "bar",
+        data: {
+            labels: ["January", "February"],
+            datasets: [{label: "Sales", data: [10, 20]}]
+        },
+        options: {
+            plugins: {
+                chartjs2music: {cc},
+                ...(title ? {title: {display: true, text: title}} : {}),
+                ...(subtitle ? {subtitle: {display: true, text: subtitle}} : {})
+            }
+        }
+    } as any);
+
+    chart.update();
+    canvas.dispatchEvent(new Event("focus"));
+    return {canvas, cc, chart};
+}
+
+test("combines a chart title and subtitle", () => {
+    const {cc, chart} = createChart("Annual Sales", "North America");
+    expect(cc.textContent).toContain('Sonified chart titled "Annual Sales, North America".');
+    chart.destroy();
+});
+
+test("uses a title or subtitle when only one is present", () => {
+    const titled = createChart("Annual Sales");
+    expect(titled.cc.textContent).toContain('Sonified chart titled "Annual Sales".');
+    titled.chart.destroy();
+
+    const subtitled = createChart(undefined, "North America");
+    expect(subtitled.cc.textContent).toContain('Sonified chart titled "North America".');
+    subtitled.chart.destroy();
+});
+
+test("joins multi-line subtitle text in order", () => {
+    const {cc, chart} = createChart("Annual Sales", ["North America", "Preliminary"]);
+    expect(cc.textContent).toContain('Sonified chart titled "Annual Sales, North America, Preliminary".');
+    chart.destroy();
+});
+
+test("retains current behavior when title and subtitle are absent", () => {
+    const {cc, chart} = createChart();
+    expect(cc.textContent).toContain("Sonified chart. Bar chart.");
+    chart.destroy();
+});
+
+test("refreshes the accessible description after a subtitle update", () => {
+    const {canvas, cc, chart} = createChart("Annual Sales", "North America");
+    (chart.options.plugins?.subtitle as any).text = "Europe";
+    chart.update();
+    canvas.dispatchEvent(new Event("focus"));
+
+    expect(cc.textContent).toContain('Sonified chart titled "Annual Sales, Europe".');
+    chart.destroy();
+});


### PR DESCRIPTION
## Summary
- include the built-in Chart.js subtitle in Chart2Music titles
- normalize string and multi-line title/subtitle text into `TITLE, SUBTITLE`
- recreate the C2M instance when a title or subtitle changes through `chart.update()` while preserving its existing live-region element
- add title/subtitle Storybook sample, Jest coverage, and README support notes

Closes #403

## Validation
- `tests/chartTitles.test.ts` and `tests/dynamicUpdates.test.ts` pass with coverage disabled

The temporary checkout's combined Rollup/Storybook build did not complete after the dependency tree was junctioned to the original local checkout. GitHub Actions will run the repository's canonical Yarn-based build and full suite.
