### PR TITLE
Prevent word clouds from moving on focus

### DIFF
--- a/src/c2m-plugin.ts
+++ b/src/c2m-plugin.ts
@@ -364,6 +364,13 @@ const displayPoint = (chart: Chart) => {
     if(!chartStates.has(chart)){
         return;
     }
+
+    // Word-cloud controllers lay out words during chart updates. Updating only
+    // to mirror Chart2Music focus makes the cloud jump away from the user.
+    if(chart.config.type === "wordCloud"){
+        return;
+    }
+
     const {c2m: ref} = chartStates.get(chart) as ChartStatesTypes;
     const {point, index} = ref.getCurrent();
 

--- a/tests/wordCloud.test.ts
+++ b/tests/wordCloud.test.ts
@@ -1,0 +1,17 @@
+import {CategoryScale, Chart, LinearScale} from "chart.js";
+import {WordCloudController, WordElement} from "chartjs-chart-wordcloud";
+import plugin from "../src/c2m-plugin";
+import wordCloud from "../stories/charts/wordcloud";
+
+Chart.register(CategoryScale, LinearScale, WordCloudController, WordElement, plugin);
+
+test("does not update a word cloud when Chart2Music focus changes", () => {
+    const canvas = document.createElement("canvas");
+    const chart = new Chart(canvas, wordCloud as any);
+    const update = jest.spyOn(chart, "update");
+
+    canvas.dispatchEvent(new Event("focus"));
+
+    expect(update).not.toHaveBeenCalled();
+    chart.destroy();
+});


### PR DESCRIPTION
## Summary
- prevent Chart2Music focus from triggering a Chart.js word-cloud re-layout
- add a regression test that verifies focus does not call chart.update()

## Verification
- GitHub Actions build is running.