### PR TITLE
Represent empty matrix cells as missing

### DIFF
--- a/src/c2m-plugin.ts
+++ b/src/c2m-plugin.ts
@@ -225,7 +225,7 @@ const processMatrixDataPoints = (data: any[], datasetIndex: number, xLabels: str
     });
 }
 
-const processMatrixData = (data: any) => {
+export const processMatrixData = (data: any) => {
     const xLabels: string[] = [];
     const yLabels: string[] = [];
 
@@ -248,7 +248,17 @@ const processMatrixData = (data: any) => {
         });
     });
 
-    Object.values(result).forEach((row) => row.sort((a, b) => a.x - b.x));
+    const xValues = [...new Set(Object.values(result).flatMap((row: any) => row.map((point: any) => point.x)))].sort((a, b) => a - b);
+    Object.values(result).forEach((row) => {
+        const points = row as any[];
+        const populated = new Map(points.map((point) => [point.x, point]));
+        const missingCells = xValues.filter((x) => !populated.has(x)).map((x) => ({
+            x,
+            y: NaN,
+            custom: {group: -1, index: -1}
+        }));
+        row.splice(0, row.length, ...[...points, ...missingCells].sort((a, b) => a.x - b.x));
+    });
     return {groups: Object.keys(result), data: result, xLabels, yLabels};
 }
 
@@ -375,10 +385,12 @@ const displayPoint = (chart: Chart) => {
         const highlightElements = [];
         if("custom" in point){
             const customPoint = point as typeof point & { custom: CustomDataPoint };
-            highlightElements.push({
-                datasetIndex: customPoint.custom.datasetIndex ?? customPoint.custom.group,
-                index: customPoint.custom.index
-            });
+            if(customPoint.custom.index >= 0){
+                highlightElements.push({
+                    datasetIndex: customPoint.custom.datasetIndex ?? customPoint.custom.group,
+                    index: customPoint.custom.index
+                });
+            }
         }else{
             // For stacked charts, Chart2Music includes an "All" group at index 0,
             // so we subtract 1 to get the actual dataset index

--- a/tests/matrix.test.ts
+++ b/tests/matrix.test.ts
@@ -1,7 +1,7 @@
 import {CategoryScale, Chart, LinearScale} from "chart.js";
 import {MatrixController, MatrixElement} from "chartjs-chart-matrix";
 import "chartjs-adapter-luxon";
-import plugin from "../src/c2m-plugin";
+import plugin, {processMatrixData} from "../src/c2m-plugin";
 import matrixChart from "../stories/charts/matrix";
 import matrixBasic from "../stories/charts/matrix_basic";
 import matrixCalendar from "../stories/charts/matrix_calendar";
@@ -20,6 +20,23 @@ class MockAudioEngine {
 }
 
 describe("Matrix charts", () => {
+    test("fills missing matrix cells with missing values for Chart2Music", () => {
+        const processed = processMatrixData({
+            datasets: [{
+                data: [{x: 0, y: 0, v: 10}, {x: 1, y: 1, v: 20}]
+            }]
+        });
+
+        expect(processed.data["0"]).toEqual(expect.arrayContaining([
+            expect.objectContaining({x: 0, y: 0}),
+            expect.objectContaining({x: 1, y: NaN, custom: {group: -1, index: -1}})
+        ]));
+        expect(processed.data["1"]).toEqual(expect.arrayContaining([
+            expect.objectContaining({x: 0, y: NaN, custom: {group: -1, index: -1}}),
+            expect.objectContaining({x: 1, y: 1})
+        ]));
+    });
+
     test("navigates columns with right and rows with up", () => {
         const createChart = () => {
             const parent = document.createElement("div");


### PR DESCRIPTION
## Summary
- complete each matrix row across discovered columns for Chart2Music navigation
- represent absent cells with a missing (NaN) value without adding visual Chart.js points
- avoid highlighting a Chart.js cell for a missing matrix value
- add regression coverage for sparse matrix data

## Verification
- TypeScript syntax transpilation completed
- GitHub Actions build is running.