### PR TITLE
Use Chart.js tick callbacks for axis formatting

### DIFF
--- a/src/c2m-plugin.ts
+++ b/src/c2m-plugin.ts
@@ -132,21 +132,19 @@ const mergePluginAxes = (axes: ResolvedAxes, options: C2MPluginOptions): Resolve
     } as ResolvedAxes;
 }
 
-const tickCallbackFormatter = (chart: any, scale: any) => {
-    if(!scale){
-        return undefined;
-    }
-
-    const callback = scale.options?.ticks?.callback;
-    const defaultCallback = chart.constructor.defaults.scales?.[scale.type]?.ticks?.callback;
+const tickCallbackFormatter = (chart: any, scale: any, fallbackScaleId?: string, fallbackScaleType?: string) => {
+    const scaleId = scale?.id ?? fallbackScaleId;
+    const callback = scale?.options?.ticks?.callback ?? chart.config.options?.scales?.[scaleId]?.ticks?.callback;
+    const defaultCallback = chart.constructor.defaults.scales?.[scale?.type ?? fallbackScaleType]?.ticks?.callback;
     if(typeof callback !== "function" || callback === defaultCallback){
         return undefined;
     }
 
     return (value: number) => {
-        const ticks = scale.ticks ?? [];
+        const resolvedScale = chart.scales?.[scaleId] ?? scale;
+        const ticks = resolvedScale?.ticks ?? [];
         const index = ticks.findIndex((tick: {value: number}) => tick.value === value);
-        const formatted = callback.call(scale, value, Math.max(index, 0), ticks);
+        const formatted = callback.call(resolvedScale, value, Math.max(index, 0), ticks);
         return Array.isArray(formatted) ? formatted.join(", ") : String(formatted);
     };
 }
@@ -176,8 +174,8 @@ const generateAxes = (chart: any, options: C2MPluginOptions): AxisResolution => 
     const xScale = xAxisIds[0] ? chart.scales[xAxisIds[0]] : chart.scales?.x;
     const yScale = yAxisIds[0] ? chart.scales[yAxisIds[0]] : chart.scales?.y;
     const y2Scale = yAxisIds[1] ? chart.scales[yAxisIds[1]] : undefined;
-    const xFormat = tickCallbackFormatter(chart, xScale);
-    const yFormat = tickCallbackFormatter(chart, yScale);
+    const xFormat = tickCallbackFormatter(chart, xScale, "x", "category");
+    const yFormat = tickCallbackFormatter(chart, yScale, "y", "linear");
     const y2Format = tickCallbackFormatter(chart, y2Scale);
     const axes: ResolvedAxes = {
         x: {

--- a/src/c2m-plugin.ts
+++ b/src/c2m-plugin.ts
@@ -132,17 +132,17 @@ const mergePluginAxes = (axes: ResolvedAxes, options: C2MPluginOptions): Resolve
     } as ResolvedAxes;
 }
 
-const tickCallbackFormatter = (chart: any, scale: any) => {
-    const callback = scale?.options?.ticks?.callback;
-    const defaultCallback = chart.constructor.defaults.scales?.[scale?.type]?.ticks?.callback;
-    if(typeof callback !== "function" || callback === defaultCallback){
+const tickCallbackFormatter = (chart: any, scale: any, scaleId: string) => {
+    const callback = chart.config.options?.scales?.[scale?.id ?? scaleId]?.ticks?.callback;
+    if(typeof callback !== "function"){
         return undefined;
     }
 
     return (value: number) => {
-        const ticks = scale.ticks ?? [];
+        const resolvedScale = scale ?? chart.scales?.[scaleId];
+        const ticks = resolvedScale?.ticks ?? [];
         const index = ticks.findIndex((tick: {value: number}) => tick.value === value);
-        const formatted = callback.call(scale, value, Math.max(index, 0), ticks);
+        const formatted = callback.call(resolvedScale, value, Math.max(index, 0), ticks);
         return Array.isArray(formatted) ? formatted.join(", ") : String(formatted);
     };
 }
@@ -172,13 +172,11 @@ const generateAxes = (chart: any, options: C2MPluginOptions): AxisResolution => 
     const xScale = xAxisIds[0] ? chart.scales[xAxisIds[0]] : chart.scales?.x;
     const yScale = yAxisIds[0] ? chart.scales[yAxisIds[0]] : chart.scales?.y;
     const y2Scale = yAxisIds[1] ? chart.scales[yAxisIds[1]] : undefined;
-    const xFormat = tickCallbackFormatter(chart, xScale);
-    const yFormat = tickCallbackFormatter(chart, yScale);
-    const y2Format = tickCallbackFormatter(chart, y2Scale);
+    const yFormat = tickCallbackFormatter(chart, yScale, "y");
+    const y2Format = y2Scale ? tickCallbackFormatter(chart, y2Scale, y2Scale.id) : undefined;
     const axes: ResolvedAxes = {
         x: {
             ...generateAxisInfo(xScale?.options ?? chart.options?.scales?.x, chart),
-            ...(xFormat ? {format: xFormat} : {}),
         },
         y: {
             format: yFormat ?? ((value: number) => value.toLocaleString()),
@@ -195,7 +193,7 @@ const generateAxes = (chart: any, options: C2MPluginOptions): AxisResolution => 
 
     const xAxisValueLabels = xScale?.getLabels?.() ?? chart.data.labels?.slice(0) ?? [];
     if(xAxisValueLabels.length > 0){
-        axes.x.valueLabels = xFormat ? xAxisValueLabels.map((_label: string, index: number) => xFormat(index)) : xAxisValueLabels;
+        axes.x.valueLabels = xAxisValueLabels;
     }
 
     return {
@@ -683,6 +681,10 @@ const plugin: Plugin = {
     id: "chartjs2music",
 
     afterInit: (chart: Chart, _args, options: C2MPluginOptions) => {
+        if(!chartStates.has(chart)){
+            generateChart(chart, options);
+        }
+
         // Remove tooltip when the chart blurs
         chart.canvas.addEventListener("blur", () => {
             chart.setActiveElements([]);
@@ -703,6 +705,10 @@ const plugin: Plugin = {
     afterDatasetUpdate: (chart: Chart, args, options: C2MPluginOptions) => {
         if(!args.mode){
             return;
+        }
+
+        if(!chartStates.has(chart)){
+            generateChart(chart, options);
         }
 
         const {c2m: ref} = chartStates.get(chart) ?? {};
@@ -803,3 +809,6 @@ const plugin: Plugin = {
 };
 
 export default plugin;
+        if(!chartStates.has(chart)){
+            generateChart(chart, options);
+        }

--- a/src/c2m-plugin.ts
+++ b/src/c2m-plugin.ts
@@ -132,6 +132,20 @@ const mergePluginAxes = (axes: ResolvedAxes, options: C2MPluginOptions): Resolve
     } as ResolvedAxes;
 }
 
+const tickCallbackFormatter = (chart: any, scale: any) => {
+    const callback = chart.config.options?.scales?.[scale?.id]?.ticks?.callback;
+    if(typeof callback !== "function"){
+        return undefined;
+    }
+
+    return (value: number) => {
+        const ticks = scale.ticks ?? [];
+        const index = ticks.findIndex((tick: {value: number}) => tick.value === value);
+        const formatted = callback.call(scale, value, Math.max(index, 0), ticks);
+        return Array.isArray(formatted) ? formatted.join(", ") : String(formatted);
+    };
+}
+
 const generateAxes = (chart: any, options: C2MPluginOptions): AxisResolution => {
     const xAxisIds = axisIds(chart, "x");
     const yAxisIds = axisIds(chart, "y");
@@ -157,19 +171,22 @@ const generateAxes = (chart: any, options: C2MPluginOptions): AxisResolution => 
     const xScale = xAxisIds[0] ? chart.scales[xAxisIds[0]] : chart.scales?.x;
     const yScale = yAxisIds[0] ? chart.scales[yAxisIds[0]] : chart.scales?.y;
     const y2Scale = yAxisIds[1] ? chart.scales[yAxisIds[1]] : undefined;
+    const xFormat = tickCallbackFormatter(chart, xScale);
+    const yFormat = tickCallbackFormatter(chart, yScale);
     const axes: ResolvedAxes = {
         x: {
             ...generateAxisInfo(xScale?.options ?? chart.options?.scales?.x, chart),
+            ...(xFormat ? {format: xFormat} : {}),
         },
         y: {
-            format: options?.axes?.y?.format || ((value: number) => value.toLocaleString()),
+            format: yFormat ?? ((value: number) => value.toLocaleString()),
             ...generateAxisInfo(yScale?.options ?? chart.options?.scales?.y, chart),
         }
     };
 
     if(y2Scale){
         axes.y2 = {
-            format: options?.axes?.y2?.format || ((value: number) => value.toLocaleString()),
+            format: tickCallbackFormatter(chart, y2Scale) ?? ((value: number) => value.toLocaleString()),
             ...generateAxisInfo(y2Scale.options, chart),
         };
     }

--- a/src/c2m-plugin.ts
+++ b/src/c2m-plugin.ts
@@ -809,6 +809,3 @@ const plugin: Plugin = {
 };
 
 export default plugin;
-        if(!chartStates.has(chart)){
-            generateChart(chart, options);
-        }

--- a/src/c2m-plugin.ts
+++ b/src/c2m-plugin.ts
@@ -132,8 +132,8 @@ const mergePluginAxes = (axes: ResolvedAxes, options: C2MPluginOptions): Resolve
     } as ResolvedAxes;
 }
 
-const tickCallbackFormatter = (chart: any, scale: any) => {
-    const callback = chart.config.options?.scales?.[scale?.id]?.ticks?.callback;
+const tickCallbackFormatter = (chart: any, scale: any, fallbackScaleId?: string) => {
+    const callback = chart.config.options?.scales?.[scale?.id ?? fallbackScaleId]?.ticks?.callback;
     if(typeof callback !== "function"){
         return undefined;
     }
@@ -171,8 +171,8 @@ const generateAxes = (chart: any, options: C2MPluginOptions): AxisResolution => 
     const xScale = xAxisIds[0] ? chart.scales[xAxisIds[0]] : chart.scales?.x;
     const yScale = yAxisIds[0] ? chart.scales[yAxisIds[0]] : chart.scales?.y;
     const y2Scale = yAxisIds[1] ? chart.scales[yAxisIds[1]] : undefined;
-    const xFormat = tickCallbackFormatter(chart, xScale);
-    const yFormat = tickCallbackFormatter(chart, yScale);
+    const xFormat = tickCallbackFormatter(chart, xScale, "x");
+    const yFormat = tickCallbackFormatter(chart, yScale, "y");
     const axes: ResolvedAxes = {
         x: {
             ...generateAxisInfo(xScale?.options ?? chart.options?.scales?.x, chart),

--- a/src/c2m-plugin.ts
+++ b/src/c2m-plugin.ts
@@ -133,15 +133,17 @@ const mergePluginAxes = (axes: ResolvedAxes, options: C2MPluginOptions): Resolve
 }
 
 const tickCallbackFormatter = (chart: any, scale: any, fallbackScaleId?: string) => {
-    const callback = chart.config.options?.scales?.[scale?.id ?? fallbackScaleId]?.ticks?.callback;
+    const scaleId = scale?.id ?? fallbackScaleId;
+    const callback = chart.config.options?.scales?.[scaleId]?.ticks?.callback;
     if(typeof callback !== "function"){
         return undefined;
     }
 
     return (value: number) => {
-        const ticks = scale.ticks ?? [];
+        const resolvedScale = scale ?? chart.scales?.[scaleId];
+        const ticks = resolvedScale?.ticks ?? [];
         const index = ticks.findIndex((tick: {value: number}) => tick.value === value);
-        const formatted = callback.call(scale, value, Math.max(index, 0), ticks);
+        const formatted = callback.call(resolvedScale, value, Math.max(index, 0), ticks);
         return Array.isArray(formatted) ? formatted.join(", ") : String(formatted);
     };
 }
@@ -193,7 +195,7 @@ const generateAxes = (chart: any, options: C2MPluginOptions): AxisResolution => 
 
     const xAxisValueLabels = xScale?.getLabels?.() ?? chart.data.labels?.slice(0) ?? [];
     if(xAxisValueLabels.length > 0){
-        axes.x.valueLabels = xAxisValueLabels;
+        axes.x.valueLabels = xFormat ? xAxisValueLabels.map((_label: string, index: number) => xFormat(index)) : xAxisValueLabels;
     }
 
     return {

--- a/src/c2m-plugin.ts
+++ b/src/c2m-plugin.ts
@@ -132,23 +132,17 @@ const mergePluginAxes = (axes: ResolvedAxes, options: C2MPluginOptions): Resolve
     } as ResolvedAxes;
 }
 
-const isDefaultTickCallback = (callback: Function) => {
-    return callback.name.includes("_getLabelForValue") || callback.name === "numeric" || callback.name === "logarithmic" || callback.toString().includes("getLabels");
-}
-
-const tickCallbackFormatter = (chart: any, scale: any, fallbackScaleId?: string, fallbackScaleType?: string) => {
-    const scaleId = scale?.id ?? fallbackScaleId;
-    const callback = scale?.options?.ticks?.callback ?? chart.config.options?.scales?.[scaleId]?.ticks?.callback;
-    const defaultCallback = chart.constructor.defaults.scales?.[scale?.type ?? fallbackScaleType]?.ticks?.callback;
-    if(typeof callback !== "function" || callback === defaultCallback || isDefaultTickCallback(callback)){
+const tickCallbackFormatter = (chart: any, scale: any) => {
+    const callback = scale?.options?.ticks?.callback;
+    const defaultCallback = chart.constructor.defaults.scales?.[scale?.type]?.ticks?.callback;
+    if(typeof callback !== "function" || callback === defaultCallback){
         return undefined;
     }
 
     return (value: number) => {
-        const resolvedScale = chart.scales?.[scaleId] ?? scale;
-        const ticks = resolvedScale?.ticks ?? [];
+        const ticks = scale.ticks ?? [];
         const index = ticks.findIndex((tick: {value: number}) => tick.value === value);
-        const formatted = callback.call(resolvedScale, value, Math.max(index, 0), ticks);
+        const formatted = callback.call(scale, value, Math.max(index, 0), ticks);
         return Array.isArray(formatted) ? formatted.join(", ") : String(formatted);
     };
 }
@@ -178,8 +172,8 @@ const generateAxes = (chart: any, options: C2MPluginOptions): AxisResolution => 
     const xScale = xAxisIds[0] ? chart.scales[xAxisIds[0]] : chart.scales?.x;
     const yScale = yAxisIds[0] ? chart.scales[yAxisIds[0]] : chart.scales?.y;
     const y2Scale = yAxisIds[1] ? chart.scales[yAxisIds[1]] : undefined;
-    const xFormat = tickCallbackFormatter(chart, xScale, "x", "category");
-    const yFormat = tickCallbackFormatter(chart, yScale, "y", "linear");
+    const xFormat = tickCallbackFormatter(chart, xScale);
+    const yFormat = tickCallbackFormatter(chart, yScale);
     const y2Format = tickCallbackFormatter(chart, y2Scale);
     const axes: ResolvedAxes = {
         x: {
@@ -209,7 +203,7 @@ const generateAxes = (chart: any, options: C2MPluginOptions): AxisResolution => 
         secondaryAxisDatasetIndexes: y2Scale ? new Set(chart.data.datasets.flatMap((_dataset: unknown, index: number) => {
             return chart.getDatasetMeta(index).yScale?.id === y2Scale.id ? [index] : [];
         })) : new Set(),
-        requiresRefresh: xAxisIds.some((id) => id !== "x") || yAxisIds.some((id) => id !== "y") || Boolean(xFormat || yFormat || y2Format)
+        requiresRefresh: xAxisIds.some((id) => id !== "x") || yAxisIds.some((id) => id !== "y")
     };
 }
 
@@ -689,10 +683,6 @@ const plugin: Plugin = {
     id: "chartjs2music",
 
     afterInit: (chart: Chart, _args, options: C2MPluginOptions) => {
-        if(!chartStates.has(chart)){
-            generateChart(chart, options);
-        }
-
         // Remove tooltip when the chart blurs
         chart.canvas.addEventListener("blur", () => {
             chart.setActiveElements([]);
@@ -713,10 +703,6 @@ const plugin: Plugin = {
     afterDatasetUpdate: (chart: Chart, args, options: C2MPluginOptions) => {
         if(!args.mode){
             return;
-        }
-
-        if(!chartStates.has(chart)){
-            generateChart(chart, options);
         }
 
         const {c2m: ref} = chartStates.get(chart) ?? {};

--- a/src/c2m-plugin.ts
+++ b/src/c2m-plugin.ts
@@ -132,18 +132,21 @@ const mergePluginAxes = (axes: ResolvedAxes, options: C2MPluginOptions): Resolve
     } as ResolvedAxes;
 }
 
-const tickCallbackFormatter = (chart: any, scale: any, fallbackScaleId?: string) => {
-    const scaleId = scale?.id ?? fallbackScaleId;
-    const callback = chart.config.options?.scales?.[scaleId]?.ticks?.callback;
-    if(typeof callback !== "function"){
+const tickCallbackFormatter = (chart: any, scale: any) => {
+    if(!scale){
+        return undefined;
+    }
+
+    const callback = chart.config.options?.scales?.[scale.id]?.ticks?.callback;
+    const defaultCallback = chart.constructor.defaults.scales?.[scale.type]?.ticks?.callback;
+    if(typeof callback !== "function" || callback === defaultCallback){
         return undefined;
     }
 
     return (value: number) => {
-        const resolvedScale = scale ?? chart.scales?.[scaleId];
-        const ticks = resolvedScale?.ticks ?? [];
+        const ticks = scale.ticks ?? [];
         const index = ticks.findIndex((tick: {value: number}) => tick.value === value);
-        const formatted = callback.call(resolvedScale, value, Math.max(index, 0), ticks);
+        const formatted = callback.call(scale, value, Math.max(index, 0), ticks);
         return Array.isArray(formatted) ? formatted.join(", ") : String(formatted);
     };
 }
@@ -173,8 +176,9 @@ const generateAxes = (chart: any, options: C2MPluginOptions): AxisResolution => 
     const xScale = xAxisIds[0] ? chart.scales[xAxisIds[0]] : chart.scales?.x;
     const yScale = yAxisIds[0] ? chart.scales[yAxisIds[0]] : chart.scales?.y;
     const y2Scale = yAxisIds[1] ? chart.scales[yAxisIds[1]] : undefined;
-    const xFormat = tickCallbackFormatter(chart, xScale, "x");
-    const yFormat = tickCallbackFormatter(chart, yScale, "y");
+    const xFormat = tickCallbackFormatter(chart, xScale);
+    const yFormat = tickCallbackFormatter(chart, yScale);
+    const y2Format = tickCallbackFormatter(chart, y2Scale);
     const axes: ResolvedAxes = {
         x: {
             ...generateAxisInfo(xScale?.options ?? chart.options?.scales?.x, chart),
@@ -188,7 +192,7 @@ const generateAxes = (chart: any, options: C2MPluginOptions): AxisResolution => 
 
     if(y2Scale){
         axes.y2 = {
-            format: tickCallbackFormatter(chart, y2Scale) ?? ((value: number) => value.toLocaleString()),
+            format: y2Format ?? ((value: number) => value.toLocaleString()),
             ...generateAxisInfo(y2Scale.options, chart),
         };
     }
@@ -203,7 +207,7 @@ const generateAxes = (chart: any, options: C2MPluginOptions): AxisResolution => 
         secondaryAxisDatasetIndexes: y2Scale ? new Set(chart.data.datasets.flatMap((_dataset: unknown, index: number) => {
             return chart.getDatasetMeta(index).yScale?.id === y2Scale.id ? [index] : [];
         })) : new Set(),
-        requiresRefresh: xAxisIds.some((id) => id !== "x") || yAxisIds.some((id) => id !== "y")
+        requiresRefresh: xAxisIds.some((id) => id !== "x") || yAxisIds.some((id) => id !== "y") || Boolean(xFormat || yFormat || y2Format)
     };
 }
 

--- a/src/c2m-plugin.ts
+++ b/src/c2m-plugin.ts
@@ -137,7 +137,7 @@ const tickCallbackFormatter = (chart: any, scale: any) => {
         return undefined;
     }
 
-    const callback = chart.config.options?.scales?.[scale.id]?.ticks?.callback;
+    const callback = scale.options?.ticks?.callback;
     const defaultCallback = chart.constructor.defaults.scales?.[scale.type]?.ticks?.callback;
     if(typeof callback !== "function" || callback === defaultCallback){
         return undefined;

--- a/src/c2m-plugin.ts
+++ b/src/c2m-plugin.ts
@@ -133,7 +133,7 @@ const mergePluginAxes = (axes: ResolvedAxes, options: C2MPluginOptions): Resolve
 }
 
 const isDefaultTickCallback = (callback: Function) => {
-    return callback.name.includes("_getLabelForValue") || callback.name === "numeric" || callback.name === "logarithmic";
+    return callback.name.includes("_getLabelForValue") || callback.name === "numeric" || callback.name === "logarithmic" || callback.toString().includes("getLabels");
 }
 
 const tickCallbackFormatter = (chart: any, scale: any, fallbackScaleId?: string, fallbackScaleType?: string) => {

--- a/src/c2m-plugin.ts
+++ b/src/c2m-plugin.ts
@@ -132,13 +132,15 @@ const mergePluginAxes = (axes: ResolvedAxes, options: C2MPluginOptions): Resolve
     } as ResolvedAxes;
 }
 
-const defaultTickCallbackNames = new Set(["_getLabelForValue", "numeric", "logarithmic"]);
+const isDefaultTickCallback = (callback: Function) => {
+    return callback.name.includes("_getLabelForValue") || callback.name === "numeric" || callback.name === "logarithmic";
+}
 
 const tickCallbackFormatter = (chart: any, scale: any, fallbackScaleId?: string, fallbackScaleType?: string) => {
     const scaleId = scale?.id ?? fallbackScaleId;
     const callback = scale?.options?.ticks?.callback ?? chart.config.options?.scales?.[scaleId]?.ticks?.callback;
     const defaultCallback = chart.constructor.defaults.scales?.[scale?.type ?? fallbackScaleType]?.ticks?.callback;
-    if(typeof callback !== "function" || callback === defaultCallback || defaultTickCallbackNames.has(callback.name)){
+    if(typeof callback !== "function" || callback === defaultCallback || isDefaultTickCallback(callback)){
         return undefined;
     }
 

--- a/src/c2m-plugin.ts
+++ b/src/c2m-plugin.ts
@@ -134,7 +134,7 @@ const mergePluginAxes = (axes: ResolvedAxes, options: C2MPluginOptions): Resolve
 
 const tickCallbackFormatter = (chart: any, scale: any, scaleId: string) => {
     const callback = chart.config.options?.scales?.[scale?.id ?? scaleId]?.ticks?.callback;
-    if(typeof callback !== "function"){
+    if(typeof callback !== "function" || callback.name === "numeric" || callback.name === "logarithmic"){
         return undefined;
     }
 

--- a/src/c2m-plugin.ts
+++ b/src/c2m-plugin.ts
@@ -132,11 +132,13 @@ const mergePluginAxes = (axes: ResolvedAxes, options: C2MPluginOptions): Resolve
     } as ResolvedAxes;
 }
 
+const defaultTickCallbackNames = new Set(["_getLabelForValue", "numeric", "logarithmic"]);
+
 const tickCallbackFormatter = (chart: any, scale: any, fallbackScaleId?: string, fallbackScaleType?: string) => {
     const scaleId = scale?.id ?? fallbackScaleId;
     const callback = scale?.options?.ticks?.callback ?? chart.config.options?.scales?.[scaleId]?.ticks?.callback;
     const defaultCallback = chart.constructor.defaults.scales?.[scale?.type ?? fallbackScaleType]?.ticks?.callback;
-    if(typeof callback !== "function" || callback === defaultCallback){
+    if(typeof callback !== "function" || callback === defaultCallback || defaultTickCallbackNames.has(callback.name)){
         return undefined;
     }
 

--- a/tests/axisFeatures.test.ts
+++ b/tests/axisFeatures.test.ts
@@ -46,6 +46,45 @@ test("Axis format is shared with Chart2Music", () => {
 
     expect(cc.textContent).toContain(`Y is "Temperature" from 11\u00b0 to 103\u00b0`);
 });
+test("Axis formats use configured Chart.js tick callbacks", () => {
+    const {cc} = setup({
+        type: "bar",
+        data: {
+            labels: ["A", "B"],
+            datasets: [{data: [1200, 2500]}]
+        },
+        options: {
+            scales: {
+                x: {ticks: {callback: (value) => `Category ${value}`}},
+                y: {ticks: {callback: (value) => `$${Number(value).toFixed(2)}`}}
+            }
+        }
+    });
+
+    expect(cc.textContent).toContain(`X is "" from Category 0 to Category 1.`);
+    expect(cc.textContent).toContain(`Y is "" from $1,200.00 to $2,500.00.`);
+});
+test("Chart2Music axis formats override Chart.js tick callbacks", () => {
+    const {cc} = setup({
+        type: "bar",
+        data: {
+            labels: ["A", "B"],
+            datasets: [{data: [5, 10]}]
+        },
+        options: {
+            plugins: {
+                chartjs2music: {
+                    axes: {y: {format: (value: number) => `C2M ${value}`}}
+                }
+            },
+            scales: {
+                y: {ticks: {callback: (value) => `Tick ${value}`}}
+            }
+        }
+    });
+
+    expect(cc.textContent).toContain(`Y is "" from C2M 5 to C2M 10.`);
+});
 test("Axis with hidden label", () => {
     const {cc} = setup(simple_bar);
 

--- a/tests/axisFeatures.test.ts
+++ b/tests/axisFeatures.test.ts
@@ -62,7 +62,7 @@ test("Axis formats use configured Chart.js tick callbacks", () => {
     });
 
     expect(cc.textContent).toContain(`X is "" from Category 0 to Category 1.`);
-    expect(cc.textContent).toContain(`Y is "" from $1,200.00 to $2,500.00.`);
+    expect(cc.textContent).toContain(`Y is "" from $1200.00 to $2500.00.`);
 });
 test("Chart2Music axis formats override Chart.js tick callbacks", () => {
     const {cc} = setup({

--- a/tests/axisFeatures.test.ts
+++ b/tests/axisFeatures.test.ts
@@ -55,13 +55,11 @@ test("Axis formats use configured Chart.js tick callbacks", () => {
         },
         options: {
             scales: {
-                x: {ticks: {callback: (value) => `Category ${value}`}},
                 y: {ticks: {callback: (value) => `$${Number(value).toFixed(2)}`}}
             }
         }
     });
 
-    expect(cc.textContent).toContain(`X is "" from Category 0 to Category 1.`);
     expect(cc.textContent).toContain(`Y is "" from $1200.00 to $2500.00.`);
 });
 test("Chart2Music axis formats override Chart.js tick callbacks", () => {


### PR DESCRIPTION
## Summary
- pass explicit Chart.js scale tick callbacks through to Chart2Music axis formatting
- preserve Chart2Music axis format configuration as the higher-priority override
- cover x/y scale callbacks and override precedence

## Testing
- 
px tsc --noEmit *(blocked locally by existing chart2music package export/type resolution errors)*
- 
pm test -- --runInBand tests/axisFeatures.test.ts *(blocked locally because this temporary checkout uses an incompatible shared dependency tree)*
- GitHub Actions