### PR TITLE
Support chartjs-plugin-zoom

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,12 @@ The plugin supports Chart.js bar, line, pie, doughnut, polar area, and scatter c
 - Bar charts with error bars from [`chartjs-chart-error-bars`](https://www.npmjs.com/package/chartjs-chart-error-bars).
 - Matrix plots from [`chartjs-chart-matrix`](https://www.npmjs.com/package/chartjs-chart-matrix).
 - Word clouds from [`chartjs-chart-wordcloud`](https://www.npmjs.com/package/chartjs-chart-wordcloud).
+- Zoom and pan interactions from [`chartjs-plugin-zoom`](https://www.npmjs.com/package/chartjs-plugin-zoom).
 - Chart titles and subtitles, axis titles, custom scale IDs, secondary Y axes, minimum and maximum values, linear and logarithmic axes, custom axis formatting, dataset visibility, chart data updates, and `xAxisKey` / `yAxisKey` parsing mappings for bar, line, and scatter charts.
 
 Visual-only Chart.js settings such as color, padding, and line thickness do not affect the sonification. Parsing mappings use Chart.js `xAxisKey` and `yAxisKey` options at either the chart or dataset level.
+
+When using `chartjs-plugin-zoom`, install and register it alongside this plugin. Chart2Music follows the visible range and navigates only visible points. Focus the chart and use Ctrl/Cmd + `+`, `-`, or `0` to zoom in, zoom out, or reset without triggering browser zoom. Use Alt+Shift plus an arrow key to pan; Chart2Music announces the updated axis or the relevant edge.
 
 ## Future support
 
@@ -150,7 +153,6 @@ Planned support includes:
 
 - Radar plots.
 - Parallel coordinate plots via [`chartjs-chart-pcp`](https://www.npmjs.com/package/chartjs-chart-pcp).
-- Zoom interactions via [`chartjs-plugin-zoom`](https://www.npmjs.com/package/chartjs-plugin-zoom).
 
 ## Examples and Storybook
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "chartjs-chart-matrix": "3.0.5",
     "chartjs-chart-wordcloud": "4.4.5",
     "chartjs-plugin-a11y-legend": "0.2.2",
+    "chartjs-plugin-zoom": "^2.2.0",
     "cross-env": "^10.1.0",
     "depcheck": "1.4.7",
     "jest": "^30.4.2",

--- a/src/c2m-plugin.ts
+++ b/src/c2m-plugin.ts
@@ -21,7 +21,16 @@ type ChartStatesTypes = {
     title: string;
     matrixKeydown?: (event: KeyboardEvent) => void;
     matrixKeydownTarget?: HTMLCanvasElement;
+    zoomKeydown?: (event: KeyboardEvent) => void;
+    zoomKeydownTarget?: HTMLCanvasElement;
+    viewport?: string;
+    pendingViewportAction?: ViewportAction;
 }
+
+type ViewportAction = {
+    type: "zoom-in" | "zoom-out" | "reset" | "pan";
+    direction?: "left" | "right" | "up" | "down";
+};
 
 const chartStates = new Map<Chart, ChartStatesTypes>();
 
@@ -203,6 +212,92 @@ const generateAxes = (chart: any, options: C2MPluginOptions): AxisResolution => 
         })) : new Set(),
         requiresRefresh: xAxisIds.some((id) => id !== "x") || yAxisIds.some((id) => id !== "y")
     };
+}
+
+const viewportSnapshot = (chart: Chart) => {
+    return JSON.stringify(Object.values(chart.scales)
+        .filter((scale: any) => scale.isHorizontal?.() || scale.axis === "y")
+        .map((scale: any) => ({id: scale.id, axis: scale.axis, min: scale.min, max: scale.max}))
+        .sort((a, b) => a.id.localeCompare(b.id)));
+}
+
+const applyViewportRanges = (chart: Chart, axes: ResolvedAxes): ResolvedAxes => {
+    const xAxisIds = axisIds(chart, "x");
+    const yAxisIds = axisIds(chart, "y");
+    const xScale = xAxisIds[0] ? chart.scales[xAxisIds[0]] : chart.scales?.x;
+    const yScale = yAxisIds[0] ? chart.scales[yAxisIds[0]] : chart.scales?.y;
+    const y2Scale = yAxisIds[1] ? chart.scales[yAxisIds[1]] : undefined;
+    const range = (axis: any, scale: any) => scale ? {
+        ...axis,
+        minimum: scale.min,
+        maximum: scale.max
+    } : axis;
+
+    return {
+        ...axes,
+        x: range(axes.x, xScale),
+        y: range(axes.y, yScale),
+        ...(axes.y2 ? {y2: range(axes.y2, y2Scale)} : {})
+    } as ResolvedAxes;
+}
+
+const filterDataToViewport = (chart: Chart, data: any) => {
+    return {
+        ...data,
+        datasets: data.datasets.map((dataset: any, datasetIndex: number) => {
+            const meta = chart.getDatasetMeta(datasetIndex) as any;
+            const xScale = meta.xScale;
+            const yScale = meta.yScale;
+            const filtered = (dataset.data as any[]).flatMap((point, index) => {
+                const parsed = meta._parsed?.[index];
+                if(!parsed || (xScale && (parsed.x < xScale.min || parsed.x > xScale.max)) ||
+                    (yScale && (parsed.y < yScale.min || parsed.y > yScale.max))){
+                    return [];
+                }
+                if(typeof point === "object" && point !== null){
+                    return [point];
+                }
+                return [{x: parsed.x, y: parsed.y}];
+            });
+            return {...dataset, data: filtered};
+        })
+    };
+}
+
+const axisRangeText = (name: string, axis: any) => {
+    const format = axis.format ?? ((value: unknown) => String(value));
+    const label = axis.label ? ` \"${axis.label}\"` : "";
+    const value = (raw: number) => axis.valueLabels?.[Math.round(raw)] ?? format(raw);
+    return `${name} axis${label} from ${value(axis.minimum)} to ${value(axis.maximum)}`;
+}
+
+const announce = (state: ChartStatesTypes, text: string) => {
+    const screenReader = (state.c2m as any)._sr;
+    if(screenReader?.render){
+        screenReader.render(text);
+        return;
+    }
+    state.cc.textContent = text;
+}
+
+const viewportAnnouncement = (axes: ResolvedAxes, action?: ViewportAction) => {
+    if(action?.type === "pan" && action.direction){
+        return `Panning ${action.direction}. ${axisRangeText(action.direction === "left" || action.direction === "right" ? "X" : "Y", action.direction === "left" || action.direction === "right" ? axes.x : axes.y)}.`;
+    }
+    if(action?.type === "zoom-in"){
+        return `Zoomed in. ${axisRangeText("X", axes.x)}. ${axisRangeText("Y", axes.y)}.`;
+    }
+    if(action?.type === "zoom-out"){
+        return `Zoomed out. ${axisRangeText("X", axes.x)}. ${axisRangeText("Y", axes.y)}.`;
+    }
+    if(action?.type === "reset"){
+        return `Zoom reset. ${axisRangeText("X", axes.x)}. ${axisRangeText("Y", axes.y)}.`;
+    }
+    return `Viewport updated. ${axisRangeText("X", axes.x)}. ${axisRangeText("Y", axes.y)}.`;
+}
+
+const edgeAnnouncement = (action: ViewportAction) => {
+    return `${action.direction === "left" || action.direction === "right" ? action.direction : action.direction === "up" ? "top" : "bottom"} edge.`;
 }
 
 const whichDataStructure = (data: any[]) => {
@@ -490,6 +585,106 @@ const createDataSnapshot = (chart: Chart) => {
     });
 }
 
+const zoomIsConfigured = (chart: Chart) => {
+    const zoomOptions = (chart.options.plugins as any)?.zoom;
+    const zoomable = chart as any;
+    return Boolean(zoomOptions && typeof zoomable.zoom === "function" && typeof zoomable.pan === "function" && typeof zoomable.resetZoom === "function");
+}
+
+const syncViewport = (chart: Chart, state: ChartStatesTypes, options: C2MPluginOptions) => {
+    if(!zoomIsConfigured(chart)){
+        return false;
+    }
+
+    const nextViewport = viewportSnapshot(chart);
+    if(nextViewport === state.viewport){
+        if(state.pendingViewportAction?.type === "pan"){
+            announce(state, edgeAnnouncement(state.pendingViewportAction));
+            state.pendingViewportAction = undefined;
+            return true;
+        }
+        return false;
+    }
+
+    const {valid, c2m_types} = processChartType(chart);
+    if(!valid || c2m_types === "matrix"){
+        state.viewport = nextViewport;
+        return false;
+    }
+
+    const axisResolution = generateAxes(chart, options);
+    if(axisResolution.error){
+        options.errorCallback?.(axisResolution.error);
+        return true;
+    }
+    const parsingData = resolveParsingData(chart);
+    if(parsingData.error){
+        options.errorCallback?.(parsingData.error);
+        return true;
+    }
+
+    const axes = applyViewportRanges(chart, applyErrorBarAxisRange(chart, axisResolution.axes));
+    const visibleData = filterDataToViewport(chart, parsingData.data);
+    const {data} = processData(
+        visibleData,
+        c2m_types,
+        errorBarDatasetIndexes(chart),
+        axisResolution.secondaryAxisDatasetIndexes
+    );
+    state.c2m.setData(data, axes);
+    state.viewport = nextViewport;
+    announce(state, viewportAnnouncement(axes, state.pendingViewportAction));
+    state.pendingViewportAction = undefined;
+    return true;
+}
+
+const addZoomKeyboardShortcuts = (chart: Chart, state: ChartStatesTypes) => {
+    if(!zoomIsConfigured(chart)){
+        return;
+    }
+
+    const zoomable = chart as any;
+    const keydown = (event: KeyboardEvent) => {
+        const commandKey = event.ctrlKey || event.metaKey;
+        const zoomKey = event.key === "+" || event.key === "=" || event.key === "-" || event.key === "0";
+        if(commandKey && zoomKey){
+            event.preventDefault();
+            event.stopImmediatePropagation();
+            if(event.key === "0"){
+                state.pendingViewportAction = {type: "reset"};
+                zoomable.resetZoom("none");
+            }else if(event.key === "-"){
+                state.pendingViewportAction = {type: "zoom-out"};
+                zoomable.zoom(0.8, "none");
+            }else{
+                state.pendingViewportAction = {type: "zoom-in"};
+                zoomable.zoom(1.25, "none");
+            }
+            return;
+        }
+
+        if(!event.altKey || !event.shiftKey || !["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"].includes(event.key)){
+            return;
+        }
+
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        const chartWidth = chart.chartArea.right - chart.chartArea.left;
+        const chartHeight = chart.chartArea.bottom - chart.chartArea.top;
+        const distance = Math.max(20, Math.round(Math.min(chartWidth, chartHeight) / 4));
+        const action = event.key === "ArrowLeft" ? {type: "pan" as const, direction: "left" as const, amount: {x: distance}} :
+            event.key === "ArrowRight" ? {type: "pan" as const, direction: "right" as const, amount: {x: -distance}} :
+                event.key === "ArrowUp" ? {type: "pan" as const, direction: "up" as const, amount: {y: distance}} :
+                    {type: "pan" as const, direction: "down" as const, amount: {y: -distance}};
+        state.pendingViewportAction = action;
+        zoomable.pan(action.amount, undefined, "none");
+    };
+
+    chart.canvas.addEventListener("keydown", keydown, true);
+    state.zoomKeydown = keydown;
+    state.zoomKeydownTarget = chart.canvas;
+}
+
 const displayPoint = (chart: Chart) => {
     if(!chartStates.has(chart)){
         return;
@@ -725,8 +920,11 @@ const generateChart = (chart: Chart, options: C2MPluginOptions) => {
         lastDataSnapshot: createDataSnapshot(chart),
         axesResolved: false,
         cc,
-        title: determineChartTitle(chart.options)
+        title: determineChartTitle(chart.options),
+        viewport: viewportSnapshot(chart)
     });
+
+    addZoomKeyboardShortcuts(chart, chartStates.get(chart) as ChartStatesTypes);
 
     if(c2m_types === "matrix"){
         const matrixKeydown = (event: KeyboardEvent) => {
@@ -815,6 +1013,10 @@ const plugin: Plugin = {
             return;
         }
 
+        if(syncViewport(chart, state, options)){
+            return;
+        }
+
         // Check if data has changed
         const currentSnapshot = createDataSnapshot(chart);
         if(state.axesResolved && currentSnapshot === state.lastDataSnapshot) {
@@ -877,6 +1079,9 @@ const plugin: Plugin = {
 
         if(state?.matrixKeydown && state.matrixKeydownTarget){
             state.matrixKeydownTarget.removeEventListener("keydown", state.matrixKeydown, true);
+        }
+        if(state?.zoomKeydown && state.zoomKeydownTarget){
+            state.zoomKeydownTarget.removeEventListener("keydown", state.zoomKeydown, true);
         }
         ref.cleanUp();
     },

--- a/stories/charts/zoom.ts
+++ b/stories/charts/zoom.ts
@@ -1,0 +1,70 @@
+import type {ChartConfiguration} from "chart.js";
+
+const labels = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+
+export default {
+    type: "line",
+    data: {
+        labels,
+        datasets: [{
+            label: "Monthly revenue",
+            data: [28, 42, 35, 56, 49, 65, 73, 68, 82, 77, 91, 88],
+            borderColor: "rgb(54, 162, 235)",
+            backgroundColor: "rgba(54, 162, 235, 0.2)",
+            fill: true,
+            tension: 0.25
+        }]
+    },
+    options: {
+        responsive: true,
+        plugins: {
+            title: {
+                display: true,
+                text: "Monthly revenue"
+            },
+            zoom: {
+                limits: {
+                    x: {min: "original", max: "original", minRange: 2},
+                    y: {min: 0, max: 100, minRange: 10}
+                },
+                pan: {
+                    enabled: true,
+                    mode: "xy",
+                    modifierKey: "alt",
+                    scaleMode: "xy",
+                    overScaleMode: "xy",
+                    threshold: 10,
+                    onPan: () => {},
+                    onPanComplete: () => {},
+                    onPanRejected: () => {},
+                    onPanStart: () => true
+                },
+                zoom: {
+                    mode: "xy",
+                    scaleMode: "xy",
+                    overScaleMode: "xy",
+                    wheel: {enabled: true, speed: 0.1, modifierKey: "ctrl"},
+                    drag: {
+                        enabled: true,
+                        backgroundColor: "rgba(54, 162, 235, 0.2)",
+                        borderColor: "rgb(54, 162, 235)",
+                        borderWidth: 1,
+                        drawTime: "beforeDatasetsDraw",
+                        threshold: 5,
+                        modifierKey: "shift",
+                        maintainAspectRatio: false
+                    },
+                    pinch: {enabled: true},
+                    onZoom: () => {},
+                    onZoomComplete: () => {},
+                    onZoomRejected: () => {},
+                    onZoomStart: () => true
+                }
+            }
+        },
+        scales: {
+            x: {title: {display: true, text: "Month"}},
+            y: {min: 0, max: 100, title: {display: true, text: "Revenue"}}
+        }
+    }
+} satisfies ChartConfiguration<"line">;

--- a/stories/line.stories.ts
+++ b/stories/line.stories.ts
@@ -6,6 +6,7 @@ import multiAxis from "./charts/multi_axis";
 import parsing from "./charts/parsing";
 import stringMinimum from "./charts/string_x_minimum";
 import titleSubtitle from "./charts/title_subtitle";
+import zoom from "./charts/zoom";
 import {renderSample, type SampleStoryArgs} from "./sample-chart";
 
 const meta = {
@@ -23,3 +24,4 @@ export const TitleAndSubtitle: Story = {args: {sample: titleSubtitle}};
 export const Logarithmic: Story = {args: {sample: logarithmic}};
 export const ClippedMinimum: Story = {args: {sample: stringMinimum}};
 export const Parsing: Story = {args: {sample: parsing}};
+export const ZoomAndPan: Story = {args: {sample: zoom}};

--- a/stories/sample-chart.ts
+++ b/stories/sample-chart.ts
@@ -4,6 +4,7 @@ import {BarWithErrorBar, BarWithErrorBarsController} from "chartjs-chart-error-b
 import {MatrixController, MatrixElement} from "chartjs-chart-matrix";
 import {WordCloudController, WordElement} from "chartjs-chart-wordcloud";
 import legendPlugin from "chartjs-plugin-a11y-legend";
+import zoomPlugin from "chartjs-plugin-zoom";
 import "chartjs-adapter-luxon";
 import chart2music from "../src/c2m-plugin";
 
@@ -17,6 +18,7 @@ Chart.register(
     WordCloudController,
     WordElement,
     legendPlugin,
+    zoomPlugin,
     chart2music
 );
 

--- a/tests/zoom.test.ts
+++ b/tests/zoom.test.ts
@@ -1,0 +1,114 @@
+import {
+    CategoryScale,
+    Chart,
+    LineController,
+    LineElement,
+    LinearScale,
+    PointElement
+} from "chart.js";
+import zoomPlugin from "chartjs-plugin-zoom";
+import plugin from "../src/c2m-plugin";
+
+Chart.register(CategoryScale, LineController, LineElement, LinearScale, PointElement, zoomPlugin, plugin);
+
+jest.useFakeTimers();
+
+const createChart = () => {
+    const canvas = document.createElement("canvas");
+    canvas.width = 800;
+    canvas.height = 400;
+    const cc = document.createElement("div");
+    const onFocusCallback = jest.fn();
+    const chart = new Chart(canvas, {
+        type: "line",
+        data: {
+            labels: ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"],
+            datasets: [{label: "Revenue", data: [28, 42, 35, 56, 49, 65, 73, 68, 82, 77, 91, 88]}]
+        },
+        options: {
+            responsive: false,
+            plugins: {
+                chartjs2music: {cc, options: {enableSound: false, onFocusCallback}},
+                zoom: {
+                    limits: {
+                        x: {min: "original", max: "original", minRange: 2},
+                        y: {min: 0, max: 100, minRange: 10}
+                    },
+                    pan: {enabled: true, mode: "xy"},
+                    zoom: {mode: "xy", wheel: {enabled: true}, pinch: {enabled: true}}
+                }
+            },
+            scales: {
+                x: {title: {display: true, text: "Month"}},
+                y: {min: 0, max: 100, title: {display: true, text: "Revenue"}}
+            }
+        }
+    });
+    return {canvas, cc, chart, onFocusCallback};
+}
+
+const keydown = (canvas: HTMLCanvasElement, key: string, options: KeyboardEventInit) => {
+    const event = new KeyboardEvent("keydown", {key, bubbles: true, cancelable: true, ...options});
+    canvas.dispatchEvent(event);
+    jest.advanceTimersByTime(250);
+    return event;
+}
+
+describe("chartjs-plugin-zoom integration", () => {
+    test("Ctrl/Cmd zoom shortcuts prevent browser zoom and announce the visible axes", () => {
+        const {canvas, cc, chart, onFocusCallback} = createChart();
+        const originalMaximum = chart.scales.x.max;
+
+        const zoomIn = keydown(canvas, "+", {ctrlKey: true});
+
+        expect(zoomIn.defaultPrevented).toBe(true);
+        expect(chart.scales.x.max).toBeLessThan(originalMaximum);
+        expect(cc.textContent).toContain("Zoomed in.");
+        expect(cc.textContent).toContain('X axis "Month"');
+        expect(cc.textContent).toContain('Y axis "Revenue"');
+
+        canvas.dispatchEvent(new Event("focus"));
+        expect(onFocusCallback).toHaveBeenLastCalledWith(expect.objectContaining({
+            point: expect.objectContaining({x: expect.any(Number)})
+        }));
+        expect(onFocusCallback.mock.lastCall?.[0].point.x).toBeGreaterThanOrEqual(chart.scales.x.min);
+
+        for(let index = 0; index < 12; index++){
+            keydown(canvas, "ArrowRight", {});
+        }
+        const announcedXValues = onFocusCallback.mock.calls.map(([event]) => event.point.x);
+        expect(announcedXValues.every((value) => value >= chart.scales.x.min && value <= chart.scales.x.max)).toBe(true);
+
+        const zoomOut = keydown(canvas, "-", {ctrlKey: true});
+        expect(zoomOut.defaultPrevented).toBe(true);
+        expect(cc.textContent).toContain("Zoomed out.");
+
+        const reset = keydown(canvas, "0", {metaKey: true});
+        expect(reset.defaultPrevented).toBe(true);
+        expect(chart.scales.x.max).toBe(originalMaximum);
+        expect(cc.textContent).toContain("Zoom reset.");
+        chart.destroy();
+    });
+
+    test("Alt+Shift arrows pan by axis and announce edges", () => {
+        const {canvas, cc, chart} = createChart();
+        keydown(canvas, "+", {ctrlKey: true});
+        const minimumAfterZoom = chart.scales.x.min;
+
+        const right = keydown(canvas, "ArrowRight", {altKey: true, shiftKey: true});
+        expect(right.defaultPrevented).toBe(true);
+        expect(chart.scales.x.min).toBeGreaterThan(minimumAfterZoom);
+        expect(cc.textContent).toContain("Panning right.");
+        expect(cc.textContent).toContain('X axis "Month"');
+
+        const up = keydown(canvas, "ArrowUp", {altKey: true, shiftKey: true});
+        expect(up.defaultPrevented).toBe(true);
+        expect(cc.textContent).toContain("Panning up.");
+        expect(cc.textContent).toContain('Y axis "Revenue"');
+
+        keydown(canvas, "0", {ctrlKey: true});
+        keydown(canvas, "ArrowLeft", {altKey: true, shiftKey: true});
+        expect(cc.textContent).toContain("left edge.");
+        chart.destroy();
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2327,6 +2327,11 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/hammerjs@^2.0.45":
+  version "2.0.46"
+  resolved "https://registry.yarnpkg.com/@types/hammerjs/-/hammerjs-2.0.46.tgz#381daaca1360ff8a7c8dff63f32e69745b9fb1e1"
+  integrity sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.1", "@types/istanbul-lib-coverage@^2.0.6":
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz#7739c232a1fee9b4d3ce8985f314c0c6d33549d7"
@@ -2990,6 +2995,14 @@ chartjs-plugin-a11y-legend@0.2.2:
   dependencies:
     chart.js "^4.2.1"
 
+chartjs-plugin-zoom@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/chartjs-plugin-zoom/-/chartjs-plugin-zoom-2.2.0.tgz#79928acf2d22bd60b5442e0ef73139b261c65d19"
+  integrity sha512-in6kcdiTlP6npIVLMd4zXZ08PDUXC52gZ4FAy5oyjk1zX3gKarXMAof7B9eFiisf9WOC3bh2saHg+J5WtLXZeA==
+  dependencies:
+    "@types/hammerjs" "^2.0.45"
+    hammerjs "^2.0.8"
+
 check-error@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-2.1.3.tgz#2427361117b70cca8dc89680ead32b157019caf5"
@@ -3638,6 +3651,11 @@ graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.11:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
+
+hammerjs@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/hammerjs/-/hammerjs-2.0.8.tgz#04ef77862cff2bb79d30f7692095930222bf60f1"
+  integrity sha512-tSQXBXS/MWQOn/RKckawJ61vvsDpCom87JgxiYdGwHdOa0ht0vzUWDlfioofFCRU0L+6NGDt6XzbgoJvZkMeRQ==
 
 handlebars@^4.7.9:
   version "4.7.9"


### PR DESCRIPTION
## Summary
- synchronize Chart2Music data, axis ranges, and announcements with chartjs-plugin-zoom viewports
- add Ctrl/Cmd zoom and reset controls plus Alt+Shift arrow panning with edge feedback
- add a complete Line Storybook zoom configuration and update support documentation

Closes #407.

## Validation
- yarn install --frozen-lockfile
- yarn test --runInBand
- yarn build
- yarn build-storybook
- yarn depcheck